### PR TITLE
refactor: centralize explorer config

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,6 +1,11 @@
 export const CHAIN_ID = 42161; // Arbitrum One
 export const RPC_URL = "https://arb1.arbitrum.io/rpc";
 
+export const EXPLORER_URLS = {
+  42161: "https://arbiscan.io",
+};
+export const EXPLORER = EXPLORER_URLS[CHAIN_ID];
+
 export const R3NT_ADDRESS = "0xR3NT_PROXY_PLACEHOLDER";
 export const FACTORY_ADDRESS = "0xLISTING_FACTORY_PROXY_PLACEHOLDER";
 export const USDC_ADDRESS = "0xUSDC_CANONICAL_PLACEHOLDER";

--- a/js/shared.js
+++ b/js/shared.js
@@ -1,10 +1,8 @@
 // /js/shared.js
 import { createPublicClient, createWalletClient, http, getAddress } from "../vendor/viem-2.x.min.js";
 import { arbitrum } from "../vendor/viem-2.x.min.js";
-import { RPC_URL, CHAIN_ID } from "./config.js";
+import { RPC_URL, CHAIN_ID, EXPLORER } from "./config.js";
 import { ready, getFCProvider } from "./farcaster.js";
-
-const EXPLORER = CHAIN_ID === 42161 ? "https://arbiscan.io" : "https://sepolia.arbiscan.io";
 
 export const publicClient = createPublicClient({ chain: arbitrum, transport: http(RPC_URL) });
 

--- a/js/support.js
+++ b/js/support.js
@@ -9,9 +9,8 @@ import {
   FEE_BPS,
   VIEW_PASS_SECONDS,
   APP_DOMAIN,
+  EXPLORER,
 } from "./config.js";
-
-const EXPLORER = CHAIN_ID === 42161 ? "https://arbiscan.io" : "https://sepolia.arbiscan.io";
 
 function link(addr) {
   if (!addr || addr.startsWith("0x") === false) return `<code>${addr}</code>`;


### PR DESCRIPTION
## Summary
- remove Sepolia explorer fallback
- centralize explorer URL mapping in `config.js`
- consume shared explorer config in shared and support modules

## Testing
- `for f in js/config.js js/shared.js js/support.js; do node --check $f && echo "$f ok"; done`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a49764fc3c832a9d697c91b8329efc