### PR TITLE
Notify Farcaster when pages are ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,12 @@
   <title>r3nt</title>
   <link rel="stylesheet" href="/css/styles.css" />
   <script type="module" src="/vendor/miniapp-sdk.min.js"></script>
+  <script type="module">
+    import { ready } from "/js/farcaster.js";
+    document.addEventListener("DOMContentLoaded", () => {
+      ready();
+    });
+  </script>
 </head>
 <body>
   <header>

--- a/landlord.html
+++ b/landlord.html
@@ -6,6 +6,12 @@
   <title>r3nt · Landlord</title>
   <link rel="stylesheet" href="/css/styles.css" />
   <script type="module" src="/vendor/miniapp-sdk.min.js"></script>
+  <script type="module">
+    import { ready } from "/js/farcaster.js";
+    document.addEventListener("DOMContentLoaded", () => {
+      ready();
+    });
+  </script>
   <script type="module" src="/js/landlord.js"></script>
 </head>
 <body>

--- a/support.html
+++ b/support.html
@@ -6,6 +6,12 @@
   <title>r3nt · Support</title>
   <link rel="stylesheet" href="/css/styles.css" />
   <script type="module" src="/vendor/miniapp-sdk.min.js"></script>
+  <script type="module">
+    import { ready } from "/js/farcaster.js";
+    document.addEventListener("DOMContentLoaded", () => {
+      ready();
+    });
+  </script>
   <script type="module" src="/js/support.js"></script>
 </head>
 <body>

--- a/tenant.html
+++ b/tenant.html
@@ -6,6 +6,12 @@
   <title>r3nt · Tenant</title>
   <link rel="stylesheet" href="/css/styles.css" />
   <script type="module" src="/vendor/miniapp-sdk.min.js"></script>
+  <script type="module">
+    import { ready } from "/js/farcaster.js";
+    document.addEventListener("DOMContentLoaded", () => {
+      ready();
+    });
+  </script>
   <script type="module" src="/js/tenant.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Import `ready` helper on index, landlord, tenant, and support pages
- Call `ready()` on DOMContentLoaded so each page signals readiness to Farcaster

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5afb93004832ab32dabe3dbdf4495