### PR TITLE
Load SDKs from CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>r3nt</title>
   <link rel="stylesheet" href="/css/styles.css" />
-  <script type="module" src="/vendor/miniapp-sdk.min.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@farcaster/miniapp-sdk/+esm"></script>
   <script type="module">
     import { ready } from "/js/farcaster.js";
     document.addEventListener("DOMContentLoaded", () => {

--- a/js/shared.js
+++ b/js/shared.js
@@ -1,6 +1,11 @@
 // /js/shared.js
-import { createPublicClient, createWalletClient, http, getAddress } from "../vendor/viem-2.x.min.js";
-import { arbitrum } from "../vendor/viem-2.x.min.js";
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  getAddress,
+} from "https://cdn.jsdelivr.net/npm/viem@2/+esm";
+import { arbitrum } from "https://cdn.jsdelivr.net/npm/viem@2/chains/+esm";
 import { RPC_URL, CHAIN_ID, EXPLORER } from "./config.js";
 import { ready, getFCProvider } from "./farcaster.js";
 import { showToast } from "./toast.js";

--- a/landlord.html
+++ b/landlord.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>r3nt · Landlord</title>
   <link rel="stylesheet" href="/css/styles.css" />
-  <script type="module" src="/vendor/miniapp-sdk.min.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@farcaster/miniapp-sdk/+esm"></script>
   <script type="module">
     import { ready } from "/js/farcaster.js";
     document.addEventListener("DOMContentLoaded", () => {

--- a/support.html
+++ b/support.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>r3nt · Support</title>
   <link rel="stylesheet" href="/css/styles.css" />
-  <script type="module" src="/vendor/miniapp-sdk.min.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@farcaster/miniapp-sdk/+esm"></script>
   <script type="module">
     import { ready } from "/js/farcaster.js";
     document.addEventListener("DOMContentLoaded", () => {

--- a/tenant.html
+++ b/tenant.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>r3nt · Tenant</title>
   <link rel="stylesheet" href="/css/styles.css" />
-  <script type="module" src="/vendor/miniapp-sdk.min.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@farcaster/miniapp-sdk/+esm"></script>
   <script type="module">
     import { ready } from "/js/farcaster.js";
     document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Summary
- Load Farcaster Mini App SDK from jsDelivr CDN across all HTML pages
- Import viem utilities and Arbitrum chain config directly from CDN instead of local vendor build

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b9fa2df8832aadc9f4f4f855ebab