### PR TITLE
refactor: import abi json modules

### DIFF
--- a/js/landlord.js
+++ b/js/landlord.js
@@ -15,8 +15,10 @@ import {
   USDC_ADDRESS,
 } from "./config.js";
 
-import r3ntAbi from "./abi/r3nt.json" assert { type: "json" };
-import erc20Abi from "./abi/USDC.json" assert { type: "json" };
+import r3nt from "./abi/r3nt.json" assert { type: "json" };
+const r3ntAbi = r3nt.abi;
+import usdc from "./abi/USDC.json" assert { type: "json" };
+const erc20Abi = usdc.abi;
 
 const els = {
   feeApprove: document.getElementById("fee-approve"),

--- a/js/tenant.js
+++ b/js/tenant.js
@@ -16,8 +16,10 @@ import {
   FEE_BPS,
 } from "./config.js";
 
-import r3ntAbi from "./abi/r3nt.json" assert { type: "json" };
-import erc20Abi from "./abi/USDC.json" assert { type: "json" };
+import r3nt from "./abi/r3nt.json" assert { type: "json" };
+const r3ntAbi = r3nt.abi;
+import usdc from "./abi/USDC.json" assert { type: "json" };
+const erc20Abi = usdc.abi;
 
 const els = {
   viewPass: document.getElementById("view-pass"),


### PR DESCRIPTION
## Summary
- import JSON ABI definitions and expose `r3ntAbi` and `erc20Abi` arrays
- pass ABI arrays directly to contract read/write helpers to avoid wrapper errors

## Testing
- `node --dns-result-order=ipv4first -e "import {createPublicClient, http} from 'viem'; import { arbitrum } from 'viem/chains'; import r3nt from './js/abi/r3nt.json' assert {type:'json'}; const client=createPublicClient({chain:arbitrum, transport:http('https://arb1.arbitrum.io/rpc')}); client.readContract({ address: '0x18Af5B8fFA27B8300494Aa1a8c4F6AE4ee087029', abi: r3nt.abi, functionName: 'listFee' }).then(res=>{console.log('listFee', res.toString());}).catch(e=>console.error('error', e));"` (fails: HTTP request failed; no invalid ABI errors)

------
https://chatgpt.com/codex/tasks/task_e_68a5d6395958832a9a6ac0ee86cc0deb