### PR TITLE
Use relative asset paths for static pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ It enables landlords to list properties, tenants to book with USDC, and deposits
 
 For developer and debugging guidance, see the [Farcaster Mini App Agents Checklist](https://miniapps.farcaster.xyz/docs/guides/agents-checklist). More detailed information is available in [`minapp-farcaster-llms-full.txt`](./minapp-farcaster-llms-full.txt), a local copy of the upstream `llms-full.txt`.
 
+### Hosting
+The static frontend references assets with relative paths, so it can be served from any directory. Hosting at the domain root is not required.
+
 ---
 
 ## Features

--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>r3nt</title>
-  <link rel="stylesheet" href="/css/styles.css" />
+  <link rel="stylesheet" href="./css/styles.css" />
   <script type="module" src="https://cdn.jsdelivr.net/npm/@farcaster/miniapp-sdk/+esm"></script>
   <script type="module">
-    import { ready } from "/js/farcaster.js";
+    import { ready } from "./js/farcaster.js";
     document.addEventListener("DOMContentLoaded", () => {
       ready();
     });
@@ -19,9 +19,9 @@
     <p>Arbitrum One · Platform fee 2% = 1% tenant + 1% landlord</p>
   </header>
   <main class="menu">
-    <a class="btn" href="/landlord.html">Landlord</a>
-    <a class="btn" href="/tenant.html">Tenant</a>
-    <a class="link" href="/support.html">Support & Troubleshooting</a>
+    <a class="btn" href="./landlord.html">Landlord</a>
+    <a class="btn" href="./tenant.html">Tenant</a>
+    <a class="link" href="./support.html">Support & Troubleshooting</a>
   </main>
 </body>
 </html>

--- a/landlord.html
+++ b/landlord.html
@@ -4,18 +4,18 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>r3nt · Landlord</title>
-  <link rel="stylesheet" href="/css/styles.css" />
+  <link rel="stylesheet" href="./css/styles.css" />
   <script type="module" src="https://cdn.jsdelivr.net/npm/@farcaster/miniapp-sdk/+esm"></script>
   <script type="module">
-    import { ready } from "/js/farcaster.js";
+    import { ready } from "./js/farcaster.js";
     document.addEventListener("DOMContentLoaded", () => {
       ready();
     });
   </script>
-  <script type="module" src="/js/landlord.js"></script>
+  <script type="module" src="./js/landlord.js"></script>
 </head>
 <body>
-  <header><a href="/">←</a><h2>Landlord</h2></header>
+  <header><a href="./index.html">←</a><h2>Landlord</h2></header>
   <main>
     <section id="fee-approve"></section>
     <section id="create-listing"></section>

--- a/support.html
+++ b/support.html
@@ -4,18 +4,18 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>r3nt · Support</title>
-  <link rel="stylesheet" href="/css/styles.css" />
+  <link rel="stylesheet" href="./css/styles.css" />
   <script type="module" src="https://cdn.jsdelivr.net/npm/@farcaster/miniapp-sdk/+esm"></script>
   <script type="module">
-    import { ready } from "/js/farcaster.js";
+    import { ready } from "./js/farcaster.js";
     document.addEventListener("DOMContentLoaded", () => {
       ready();
     });
   </script>
-  <script type="module" src="/js/support.js"></script>
+  <script type="module" src="./js/support.js"></script>
 </head>
 <body>
-  <header><a href="/">←</a><h2>Support</h2></header>
+  <header><a href="./index.html">←</a><h2>Support</h2></header>
   <main id="support"></main>
 </body>
 </html>

--- a/tenant.html
+++ b/tenant.html
@@ -4,18 +4,18 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>r3nt · Tenant</title>
-  <link rel="stylesheet" href="/css/styles.css" />
+  <link rel="stylesheet" href="./css/styles.css" />
   <script type="module" src="https://cdn.jsdelivr.net/npm/@farcaster/miniapp-sdk/+esm"></script>
   <script type="module">
-    import { ready } from "/js/farcaster.js";
+    import { ready } from "./js/farcaster.js";
     document.addEventListener("DOMContentLoaded", () => {
       ready();
     });
   </script>
-  <script type="module" src="/js/tenant.js"></script>
+  <script type="module" src="./js/tenant.js"></script>
 </head>
 <body>
-  <header><a href="/">←</a><h2>Tenant</h2></header>
+  <header><a href="./index.html">←</a><h2>Tenant</h2></header>
   <main>
     <section id="view-pass"></section>
     <section id="book"></section>


### PR DESCRIPTION
## Summary
- use relative paths for JS, CSS, and internal links across HTML files
- note in README that static frontend no longer requires domain-root hosting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d7ab8b60832a8c615bd849694409