### PR TITLE
refactor: centralize address helper

### DIFF
--- a/js/landlord.js
+++ b/js/landlord.js
@@ -1,14 +1,14 @@
 // /js/landlord.js
 import {
   publicClient,
-  getWalletClient,
   ensureWritable,
   toUnits,
   fromUnits,
   readVar,
   readStruct,
   simulateAndWrite,
-} from "./shared.js"; // create this helper (or inline; see tenant.js for patterns too)
+  getAddresses,
+} from "./shared.js";
 import { showToast } from "./toast.js";
 
 import {
@@ -26,11 +26,6 @@ const els = {
   createListing: document.getElementById("create-listing"),
   myListings: document.getElementById("my-listings"),
 };
-
-async function getAddresses() {
-  const w = await getWalletClient();
-  return w ? { walletClient: w.walletClient, account: w.account } : { walletClient: null, account: null };
-}
 
 async function renderApproveListFee() {
   try {

--- a/js/shared.js
+++ b/js/shared.js
@@ -21,6 +21,11 @@ export async function getWalletClient() {
   return { walletClient, account: getAddress(addr) };
 }
 
+export async function getAddresses() {
+  const w = await getWalletClient();
+  return w ? { walletClient: w.walletClient, account: w.account } : { walletClient: null, account: null };
+}
+
 export async function ensureWritable() {
   const w = await getWalletClient();
   if (!w) throw new Error("No wallet provider (Mini App).");

--- a/js/tenant.js
+++ b/js/tenant.js
@@ -1,13 +1,13 @@
 // /js/tenant.js
 import {
   publicClient,
-  getWalletClient,
   ensureWritable,
   toUnits,
   fromUnits,
   readVar,
   readStruct,
   simulateAndWrite,
+  getAddresses,
 } from "./shared.js";
 import { showToast } from "./toast.js";
 
@@ -27,11 +27,6 @@ const els = {
   book: document.getElementById("book"),
   myBookings: document.getElementById("my-bookings"),
 };
-
-async function getAddresses() {
-  const w = await getWalletClient();
-  return w ? { walletClient: w.walletClient, account: w.account } : { walletClient: null, account: null };
-}
 
 async function renderViewPass() {
   try {


### PR DESCRIPTION
## Summary
- add `getAddresses` helper in `shared.js`
- reuse `getAddresses` in landlord and tenant modules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f3f88130832ab56962be52d8b982