### PR TITLE
Defer DOM queries until DOMContentLoaded

### DIFF
--- a/js/landlord.js
+++ b/js/landlord.js
@@ -21,11 +21,7 @@ const r3ntAbi = r3nt.abi;
 import usdc from "./abi/USDC.json" assert { type: "json" };
 const erc20Abi = usdc.abi;
 
-const els = {
-  feeApprove: document.getElementById("fee-approve"),
-  createListing: document.getElementById("create-listing"),
-  myListings: document.getElementById("my-listings"),
-};
+const els = {};
 
 async function renderApproveListFee() {
   try {
@@ -262,6 +258,9 @@ async function renderMyListings() {
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
+  els.feeApprove = document.getElementById("fee-approve");
+  els.createListing = document.getElementById("create-listing");
+  els.myListings = document.getElementById("my-listings");
   try {
     await renderApproveListFee();
     await renderCreateListing();

--- a/js/tenant.js
+++ b/js/tenant.js
@@ -22,11 +22,7 @@ const r3ntAbi = r3nt.abi;
 import usdc from "./abi/USDC.json" assert { type: "json" };
 const erc20Abi = usdc.abi;
 
-const els = {
-  viewPass: document.getElementById("view-pass"),
-  book: document.getElementById("book"),
-  myBookings: document.getElementById("my-bookings"),
-};
+const els = {};
 
 async function renderViewPass() {
   try {
@@ -299,6 +295,9 @@ async function renderMyBookings() {
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
+  els.viewPass = document.getElementById("view-pass");
+  els.book = document.getElementById("book");
+  els.myBookings = document.getElementById("my-bookings");
   try {
     await renderViewPass();
     await renderBook();


### PR DESCRIPTION
## Summary
- Move landlord DOM element lookups inside DOMContentLoaded handler
- Move tenant DOM element lookups inside DOMContentLoaded handler

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a61b8346e4832a99e4fcd4b5c9cfa2