### PR TITLE
Add basic landlord, tenant, and support pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,19 @@
 <!doctype html>
 <html>
-
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>r3nt</title>
+  <link rel="stylesheet" href="./css/styles.css">
+</head>
+<body>
+  <header>
+    <h1>r3nt</h1>
+  </header>
+  <main class="menu">
+    <a class="btn" href="landlord.html">Landlord</a>
+    <a class="btn" href="tenant.html">Tenant</a>
+    <a class="btn" href="support.html">Support</a>
+  </main>
+</body>
 </html>

--- a/js/landlord.js
+++ b/js/landlord.js
@@ -1,1 +1,97 @@
 // /js/landlord.js
+import r3ntAbi from "./abi/r3nt.json" assert { type: "json" };
+import usdcAbi from "./abi/USDC.json" assert { type: "json" };
+import { R3NT_ADDRESS, USDC_ADDRESS } from "./config.js";
+import { ensureWritable, simulateAndWrite, toUnits, readVar } from "./shared.js";
+import { ready } from "./farcaster.js";
+
+ready();
+
+document.getElementById("create-form")?.addEventListener("submit", createListing);
+document.getElementById("completed-form")?.addEventListener("submit", markCompleted);
+document.getElementById("split-form")?.addEventListener("submit", proposeSplit);
+
+async function createListing(e) {
+  e.preventDefault();
+  try {
+    await ensureWritable();
+    const deposit = toUnits(document.getElementById("deposit").value);
+    const rateDaily = toUnits(document.getElementById("rateDaily").value);
+    const rateWeekly = toUnits(document.getElementById("rateWeekly").value);
+    const rateMonthly = toUnits(document.getElementById("rateMonthly").value);
+    const geohash = document.getElementById("geohash").value;
+    const geolen = geohash.length;
+    const fid = BigInt(document.getElementById("fid").value);
+    const castHash = document.getElementById("castHash").value;
+    const title = document.getElementById("title").value;
+    const shortDesc = document.getElementById("shortDesc").value;
+    const signersStr = document.getElementById("signers").value.trim();
+    const signers = signersStr ? signersStr.split(",").map(s => s.trim()) : [];
+    const threshold = BigInt(document.getElementById("threshold").value || 1);
+
+    const listFee = await readVar(R3NT_ADDRESS, r3ntAbi, "listFee");
+    await simulateAndWrite({
+      address: USDC_ADDRESS,
+      abi: usdcAbi,
+      functionName: "approve",
+      args: [R3NT_ADDRESS, listFee]
+    });
+
+    await simulateAndWrite({
+      address: R3NT_ADDRESS,
+      abi: r3ntAbi,
+      functionName: "createListing",
+      args: [
+        USDC_ADDRESS,
+        deposit,
+        rateDaily,
+        rateWeekly,
+        rateMonthly,
+        geohash,
+        geolen,
+        fid,
+        castHash,
+        title,
+        shortDesc,
+        signers,
+        threshold
+      ]
+    });
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+async function markCompleted(e) {
+  e.preventDefault();
+  try {
+    await ensureWritable();
+    const bookingId = BigInt(document.getElementById("bookingId").value);
+    await simulateAndWrite({
+      address: R3NT_ADDRESS,
+      abi: r3ntAbi,
+      functionName: "markCompleted",
+      args: [bookingId]
+    });
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+async function proposeSplit(e) {
+  e.preventDefault();
+  try {
+    await ensureWritable();
+    const bookingId = BigInt(document.getElementById("splitBookingId").value);
+    const toTenant = toUnits(document.getElementById("toTenant").value);
+    const toLandlord = toUnits(document.getElementById("toLandlord").value);
+    await simulateAndWrite({
+      address: R3NT_ADDRESS,
+      abi: r3ntAbi,
+      functionName: "proposeDepositSplit",
+      args: [bookingId, toTenant, toLandlord]
+    });
+  } catch (err) {
+    console.error(err);
+  }
+}

--- a/js/support.js
+++ b/js/support.js
@@ -1,1 +1,26 @@
 // /js/support.js
+import r3ntAbi from "./abi/r3nt.json" assert { type: "json" };
+import { R3NT_ADDRESS } from "./config.js";
+import { ensureWritable, simulateAndWrite } from "./shared.js";
+import { ready } from "./farcaster.js";
+
+ready();
+
+document.getElementById("release-form")?.addEventListener("submit", confirmRelease);
+
+async function confirmRelease(e) {
+  e.preventDefault();
+  try {
+    await ensureWritable();
+    const bookingId = BigInt(document.getElementById("bookingId").value);
+    const signature = document.getElementById("signature").value.trim();
+    await simulateAndWrite({
+      address: R3NT_ADDRESS,
+      abi: r3ntAbi,
+      functionName: "confirmDepositRelease",
+      args: [bookingId, signature]
+    });
+  } catch (err) {
+    console.error(err);
+  }
+}

--- a/js/tenant.js
+++ b/js/tenant.js
@@ -1,1 +1,76 @@
 // /js/tenant.js
+import r3ntAbi from "./abi/r3nt.json" assert { type: "json" };
+import usdcAbi from "./abi/USDC.json" assert { type: "json" };
+import { R3NT_ADDRESS, USDC_ADDRESS, FEE_BPS } from "./config.js";
+import { ensureWritable, simulateAndWrite, readVar, readStruct } from "./shared.js";
+import { ready } from "./farcaster.js";
+
+ready();
+
+document.getElementById("pass-form")?.addEventListener("submit", buyPass);
+document.getElementById("book-form")?.addEventListener("submit", book);
+
+async function buyPass(e) {
+  e.preventDefault();
+  try {
+    await ensureWritable();
+    const fee = await readVar(R3NT_ADDRESS, r3ntAbi, "viewFee");
+    await simulateAndWrite({
+      address: USDC_ADDRESS,
+      abi: usdcAbi,
+      functionName: "approve",
+      args: [R3NT_ADDRESS, fee]
+    });
+    await simulateAndWrite({
+      address: R3NT_ADDRESS,
+      abi: r3ntAbi,
+      functionName: "buyViewPass",
+      args: []
+    });
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+function calcRent(rateDaily, rateWeekly, rateMonthly, rtype, units) {
+  let rate;
+  if (rtype === 0) rate = rateDaily;
+  else if (rtype === 1) rate = rateWeekly;
+  else rate = rateMonthly;
+  if (units <= 0n) throw new Error("units=0");
+  if (rate <= 0n) throw new Error("rate not offered");
+  return rate * units;
+}
+
+async function book(e) {
+  e.preventDefault();
+  try {
+    await ensureWritable();
+    const listingId = BigInt(document.getElementById("listingId").value);
+    const rtype = Number(document.getElementById("rateType").value);
+    const units = BigInt(document.getElementById("units").value);
+    const start = BigInt(Math.floor(new Date(document.getElementById("startDate").value).getTime() / 1000));
+    const end = BigInt(Math.floor(new Date(document.getElementById("endDate").value).getTime() / 1000));
+
+    const listing = await readStruct(R3NT_ADDRESS, r3ntAbi, "getListing", [listingId]);
+    const rent = calcRent(listing.rateDaily, listing.rateWeekly, listing.rateMonthly, rtype, units);
+    const fee = rent * BigInt(FEE_BPS) / 10000n;
+    const total = rent + fee + listing.deposit;
+
+    await simulateAndWrite({
+      address: USDC_ADDRESS,
+      abi: usdcAbi,
+      functionName: "approve",
+      args: [R3NT_ADDRESS, total]
+    });
+
+    await simulateAndWrite({
+      address: R3NT_ADDRESS,
+      abi: r3ntAbi,
+      functionName: "book",
+      args: [listingId, rtype, units, start, end]
+    });
+  } catch (err) {
+    console.error(err);
+  }
+}

--- a/landlord.html
+++ b/landlord.html
@@ -1,4 +1,81 @@
 <!doctype html>
 <html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Landlord – r3nt</title>
+  <link rel="stylesheet" href="./css/styles.css">
+</head>
+<body>
+  <header>
+    <a href="index.html">&larr; Back</a>
+    <h1>Landlord</h1>
+  </header>
+  <main>
+    <form id="create-form" class="card">
+      <h2>Create Listing</h2>
+      <div class="grid">
+        <label>Deposit (USDC)
+          <input id="deposit" type="text" required>
+        </label>
+        <label>Rate Daily
+          <input id="rateDaily" type="text" required>
+        </label>
+        <label>Rate Weekly
+          <input id="rateWeekly" type="text" required>
+        </label>
+        <label>Rate Monthly
+          <input id="rateMonthly" type="text" required>
+        </label>
+        <label>Geohash
+          <input id="geohash" type="text" required>
+        </label>
+        <label>FID
+          <input id="fid" type="number" required>
+        </label>
+        <label>Cast Hash
+          <input id="castHash" type="text" placeholder="0x..." required>
+        </label>
+        <label>Title
+          <input id="title" type="text" required>
+        </label>
+        <label>Short Description
+          <textarea id="shortDesc" required></textarea>
+        </label>
+        <label>Signers (comma-separated)
+          <input id="signers" type="text" placeholder="0xabc,0xdef">
+        </label>
+        <label>Threshold
+          <input id="threshold" type="number" value="1">
+        </label>
+      </div>
+      <button class="btn" type="submit">Create</button>
+    </form>
 
+    <form id="completed-form" class="card">
+      <h2>Mark Booking Completed</h2>
+      <label>Booking ID
+        <input id="bookingId" type="number" required>
+      </label>
+      <button class="btn" type="submit">Mark Completed</button>
+    </form>
+
+    <form id="split-form" class="card">
+      <h2>Propose Deposit Split</h2>
+      <div class="grid">
+        <label>Booking ID
+          <input id="splitBookingId" type="number" required>
+        </label>
+        <label>To Tenant (USDC)
+          <input id="toTenant" type="text" required>
+        </label>
+        <label>To Landlord (USDC)
+          <input id="toLandlord" type="text" required>
+        </label>
+      </div>
+      <button class="btn" type="submit">Propose</button>
+    </form>
+  </main>
+  <script type="module" src="./js/landlord.js"></script>
+</body>
 </html>

--- a/support.html
+++ b/support.html
@@ -1,4 +1,28 @@
 <!doctype html>
 <html>
-
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Support – r3nt</title>
+  <link rel="stylesheet" href="./css/styles.css">
+</head>
+<body>
+  <header>
+    <a href="index.html">&larr; Back</a>
+    <h1>Support</h1>
+  </header>
+  <main>
+    <form id="release-form" class="card">
+      <h2>Confirm Deposit Release</h2>
+      <label>Booking ID
+        <input id="bookingId" type="number" required>
+      </label>
+      <label>Signature
+        <textarea id="signature" placeholder="0x..." required></textarea>
+      </label>
+      <button class="btn" type="submit">Confirm Release</button>
+    </form>
+  </main>
+  <script type="module" src="./js/support.js"></script>
+</body>
 </html>

--- a/tenant.html
+++ b/tenant.html
@@ -1,4 +1,48 @@
 <!doctype html>
 <html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tenant – r3nt</title>
+  <link rel="stylesheet" href="./css/styles.css">
+</head>
+<body>
+  <header>
+    <a href="index.html">&larr; Back</a>
+    <h1>Tenant</h1>
+  </header>
+  <main>
+    <form id="pass-form" class="card">
+      <h2>Buy / Renew View Pass</h2>
+      <button class="btn" type="submit">Buy View Pass</button>
+    </form>
 
+    <form id="book-form" class="card">
+      <h2>Book Listing</h2>
+      <div class="grid">
+        <label>Listing ID
+          <input id="listingId" type="number" required>
+        </label>
+        <label>Rate Type
+          <select id="rateType">
+            <option value="0">Daily</option>
+            <option value="1">Weekly</option>
+            <option value="2">Monthly</option>
+          </select>
+        </label>
+        <label>Units
+          <input id="units" type="number" required>
+        </label>
+        <label>Start Date
+          <input id="startDate" type="date" required>
+        </label>
+        <label>End Date
+          <input id="endDate" type="date" required>
+        </label>
+      </div>
+      <button class="btn" type="submit">Book</button>
+    </form>
+  </main>
+  <script type="module" src="./js/tenant.js"></script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- Build index menu linking to landlord, tenant, and support flows
- Implement landlord UI/logic for listing creation, booking completion, and deposit split
- Implement tenant UI/logic for buying view pass and booking listings
- Implement support UI/logic for confirming deposit release

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a620c14bb8832abbbd7e2a256866d3