### PR TITLE
Load Farcaster MiniApp SDK from CDN

### DIFF
--- a/js/farcaster.js
+++ b/js/farcaster.js
@@ -1,10 +1,16 @@
 // minimal FC helpers
+import { sdk as farcasterSdk } from "https://esm.sh/@farcaster/miniapp-sdk";
+
+const globalSdk = typeof window !== "undefined" ? window.sdk : undefined;
+export const sdk = globalSdk ?? farcasterSdk;
+if (typeof window !== "undefined" && !window.sdk) window.sdk = sdk;
+
 export async function ready() {
-  if (window.sdk?.actions?.ready) await window.sdk.actions.ready();
+  if (sdk?.actions?.ready) await sdk.actions.ready();
 }
 
 export async function getFCProvider() {
-  try { return await window.sdk?.wallet?.getEthereumProvider?.() ?? null; }
+  try { return await sdk.wallet?.getEthereumProvider?.() ?? null; }
   catch { return null; }
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,4 @@
 // /js/index.js
-import { ready } from "./farcaster.js";
+import { ready } from "./shared.js";
 
 ready();

--- a/js/landlord.js
+++ b/js/landlord.js
@@ -2,8 +2,7 @@
 import r3ntAbi from "./abi/r3nt.json" assert { type: "json" };
 import usdcAbi from "./abi/USDC.json" assert { type: "json" };
 import { R3NT_ADDRESS, USDC_ADDRESS } from "./config.js";
-import { ensureWritable, simulateAndWrite, toUnits, readVar } from "./shared.js";
-import { ready } from "./farcaster.js";
+import { ensureWritable, simulateAndWrite, toUnits, readVar, ready } from "./shared.js";
 
 ready();
 

--- a/js/shared.js
+++ b/js/shared.js
@@ -7,8 +7,10 @@ import {
 } from "https://cdn.jsdelivr.net/npm/viem@2.34.0/+esm";
 import { arbitrum } from "https://cdn.jsdelivr.net/npm/viem@2.34.0/chains/+esm";
 import { RPC_URL, CHAIN_ID, EXPLORER } from "./config.js";
-import { ready, getFCProvider } from "./farcaster.js";
+import { sdk, ready, getFCProvider } from "./farcaster.js";
 import { showToast } from "./toast.js";
+
+export { sdk, ready, getFCProvider };
 
 export const publicClient = createPublicClient({ chain: arbitrum, transport: http(RPC_URL) });
 

--- a/js/support.js
+++ b/js/support.js
@@ -1,8 +1,7 @@
 // /js/support.js
 import r3ntAbi from "./abi/r3nt.json" assert { type: "json" };
 import { R3NT_ADDRESS } from "./config.js";
-import { ensureWritable, simulateAndWrite } from "./shared.js";
-import { ready } from "./farcaster.js";
+import { ensureWritable, simulateAndWrite, ready } from "./shared.js";
 
 ready();
 

--- a/js/tenant.js
+++ b/js/tenant.js
@@ -2,8 +2,7 @@
 import r3ntAbi from "./abi/r3nt.json" assert { type: "json" };
 import usdcAbi from "./abi/USDC.json" assert { type: "json" };
 import { R3NT_ADDRESS, USDC_ADDRESS, FEE_BPS } from "./config.js";
-import { ensureWritable, simulateAndWrite, readVar, readStruct } from "./shared.js";
-import { ready } from "./farcaster.js";
+import { ensureWritable, simulateAndWrite, readVar, readStruct, ready } from "./shared.js";
 
 ready();
 


### PR DESCRIPTION
## Summary
- Load Farcaster MiniApp SDK from `https://esm.sh` and expose it globally.
- Re-export Farcaster helpers from shared utilities and source them across page scripts.

## Testing
- ⚠️ `npm test` *(package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a62aca469c832aaabdc684fd065883