### PR TITLE
Defer DOM queries until DOM is ready

### DIFF
--- a/js/landlord.js
+++ b/js/landlord.js
@@ -6,9 +6,11 @@ import { ensureWritable, simulateAndWrite, toUnits, readVar, ready } from "./sha
 
 ready();
 
-document.getElementById("create-form")?.addEventListener("submit", createListing);
-document.getElementById("completed-form")?.addEventListener("submit", markCompleted);
-document.getElementById("split-form")?.addEventListener("submit", proposeSplit);
+window.addEventListener("DOMContentLoaded", () => {
+  document.getElementById("create-form")?.addEventListener("submit", createListing);
+  document.getElementById("completed-form")?.addEventListener("submit", markCompleted);
+  document.getElementById("split-form")?.addEventListener("submit", proposeSplit);
+});
 
 async function createListing(e) {
   e.preventDefault();

--- a/js/support.js
+++ b/js/support.js
@@ -5,7 +5,9 @@ import { ensureWritable, simulateAndWrite, ready } from "./shared.js";
 
 ready();
 
-document.getElementById("release-form")?.addEventListener("submit", confirmRelease);
+window.addEventListener("DOMContentLoaded", () => {
+  document.getElementById("release-form")?.addEventListener("submit", confirmRelease);
+});
 
 async function confirmRelease(e) {
   e.preventDefault();

--- a/js/tenant.js
+++ b/js/tenant.js
@@ -6,8 +6,10 @@ import { ensureWritable, simulateAndWrite, readVar, readStruct, ready } from "./
 
 ready();
 
-document.getElementById("pass-form")?.addEventListener("submit", buyPass);
-document.getElementById("book-form")?.addEventListener("submit", book);
+window.addEventListener("DOMContentLoaded", () => {
+  document.getElementById("pass-form")?.addEventListener("submit", buyPass);
+  document.getElementById("book-form")?.addEventListener("submit", book);
+});
 
 async function buyPass(e) {
   e.preventDefault();


### PR DESCRIPTION
## Summary
- Attach landlord, tenant, and support form handlers after DOMContentLoaded to avoid null references

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6761faf58832a9f56cf5b0046ea62