### PR TITLE
Handle missing provider gracefully

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,5 @@
 // /js/index.js
-import { ready } from "./shared.js";
+import { ready, maybeShowReadOnlyBanner } from "./shared.js";
 
 ready();
+maybeShowReadOnlyBanner();

--- a/js/landlord.js
+++ b/js/landlord.js
@@ -2,7 +2,7 @@
 import r3ntAbi from "./abi/r3nt.json" assert { type: "json" };
 import usdcAbi from "./abi/USDC.json" assert { type: "json" };
 import { R3NT_ADDRESS, USDC_ADDRESS } from "./config.js";
-import { ensureWritable, simulateAndWrite, toUnits, readVar, ready, sdk, publicClient, getWalletClient } from "./shared.js";
+import { ensureWritable, simulateAndWrite, toUnits, readVar, ready, sdk, publicClient, getWalletClient, maybeShowReadOnlyBanner } from "./shared.js";
 
 ready();
 
@@ -19,11 +19,11 @@ window.addEventListener("DOMContentLoaded", () => {
 
 async function setupWallet() {
   try {
-    provider = await sdk.wallet.getEthereumProvider();
+    provider = await maybeShowReadOnlyBanner();
     const btn = document.getElementById("connect-btn");
     if (!btn) return;
     if (!provider) {
-      btn.style.display = "block";
+      btn.style.display = "none";
       return;
     }
     const accounts = await provider.request({ method: "eth_accounts" });
@@ -36,7 +36,7 @@ async function setupWallet() {
 
 async function connectWallet() {
   if (!provider) {
-    provider = await sdk.wallet.getEthereumProvider();
+    provider = await maybeShowReadOnlyBanner();
     if (!provider) return;
   }
   const accounts = await provider.request({ method: "eth_requestAccounts" });

--- a/js/support.js
+++ b/js/support.js
@@ -1,9 +1,10 @@
 // /js/support.js
 import r3ntAbi from "./abi/r3nt.json" assert { type: "json" };
 import { R3NT_ADDRESS } from "./config.js";
-import { ensureWritable, simulateAndWrite, ready } from "./shared.js";
+import { ensureWritable, simulateAndWrite, ready, maybeShowReadOnlyBanner } from "./shared.js";
 
 ready();
+maybeShowReadOnlyBanner();
 
 window.addEventListener("DOMContentLoaded", () => {
   document.getElementById("release-form")?.addEventListener("submit", confirmRelease);

--- a/js/tenant.js
+++ b/js/tenant.js
@@ -2,7 +2,7 @@
 import r3ntAbi from "./abi/r3nt.json" assert { type: "json" };
 import usdcAbi from "./abi/USDC.json" assert { type: "json" };
 import { R3NT_ADDRESS, USDC_ADDRESS, FEE_BPS } from "./config.js";
-import { ensureWritable, simulateAndWrite, readVar, readStruct, ready, sdk, publicClient } from "./shared.js";
+import { ensureWritable, simulateAndWrite, readVar, readStruct, ready, sdk, publicClient, maybeShowReadOnlyBanner } from "./shared.js";
 
 ready();
 
@@ -19,11 +19,11 @@ window.addEventListener("DOMContentLoaded", () => {
 
 async function setupWallet() {
   try {
-    provider = await sdk.wallet.getEthereumProvider();
+    provider = await maybeShowReadOnlyBanner();
     const btn = document.getElementById("connect-btn");
     if (!btn) return;
     if (!provider) {
-      btn.style.display = "block";
+      btn.style.display = "none";
     } else {
       const accounts = await provider.request({ method: "eth_accounts" });
       if (accounts.length > 0) {
@@ -37,7 +37,7 @@ async function setupWallet() {
 
 async function connectWallet() {
   if (!provider) {
-    provider = await sdk.wallet.getEthereumProvider();
+    provider = await maybeShowReadOnlyBanner();
     if (!provider) return;
   }
   const accounts = await provider.request({ method: "eth_requestAccounts" });


### PR DESCRIPTION
## Summary
- show read-only banner when no Farcaster wallet provider is available
- guard landlord and tenant wallet setup with provider check and hide connect button when unavailable
- invoke banner on index and support pages for consistent messaging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a67cf96e70832abfe9fd502cc25f32