### PR TITLE
Delay Farcaster ready until UI setup

### DIFF
--- a/js/farcaster.js
+++ b/js/farcaster.js
@@ -5,8 +5,11 @@ const globalSdk = typeof window !== "undefined" ? window.sdk : undefined;
 export const sdk = globalSdk ?? farcasterSdk;
 if (typeof window !== "undefined" && !window.sdk) window.sdk = sdk;
 
+let isReady = false;
 export async function ready() {
+  if (isReady) return;
   if (sdk?.actions?.ready) await sdk.actions.ready();
+  isReady = true;
 }
 
 export async function getFCProvider() {

--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,7 @@
 // /js/index.js
 import { ready, maybeShowReadOnlyBanner } from "./shared.js";
 
-ready();
-maybeShowReadOnlyBanner();
+window.addEventListener("DOMContentLoaded", async () => {
+  await maybeShowReadOnlyBanner();
+  await ready();
+});

--- a/js/landlord.js
+++ b/js/landlord.js
@@ -4,17 +4,16 @@ import usdcAbi from "./abi/USDC.json" assert { type: "json" };
 import { R3NT_ADDRESS, USDC_ADDRESS } from "./config.js";
 import { ensureWritable, simulateAndWrite, toUnits, readVar, ready, sdk, publicClient, getWalletClient, maybeShowReadOnlyBanner } from "./shared.js";
 
-ready();
-
 let provider = null;
 let account = null;
 
-window.addEventListener("DOMContentLoaded", () => {
-  setupWallet();
+window.addEventListener("DOMContentLoaded", async () => {
   document.getElementById("connect-btn")?.addEventListener("click", connectWallet);
   document.getElementById("create-form")?.addEventListener("submit", createListing);
   document.getElementById("completed-form")?.addEventListener("submit", markCompleted);
   document.getElementById("split-form")?.addEventListener("submit", proposeSplit);
+  await setupWallet();
+  await ready();
 });
 
 async function setupWallet() {

--- a/js/support.js
+++ b/js/support.js
@@ -3,11 +3,10 @@ import r3ntAbi from "./abi/r3nt.json" assert { type: "json" };
 import { R3NT_ADDRESS } from "./config.js";
 import { ensureWritable, simulateAndWrite, ready, maybeShowReadOnlyBanner } from "./shared.js";
 
-ready();
-maybeShowReadOnlyBanner();
-
-window.addEventListener("DOMContentLoaded", () => {
+window.addEventListener("DOMContentLoaded", async () => {
   document.getElementById("release-form")?.addEventListener("submit", confirmRelease);
+  await maybeShowReadOnlyBanner();
+  await ready();
 });
 
 async function confirmRelease(e) {

--- a/js/tenant.js
+++ b/js/tenant.js
@@ -4,17 +4,16 @@ import usdcAbi from "./abi/USDC.json" assert { type: "json" };
 import { R3NT_ADDRESS, USDC_ADDRESS, FEE_BPS } from "./config.js";
 import { ensureWritable, simulateAndWrite, readVar, readStruct, ready, sdk, publicClient, maybeShowReadOnlyBanner } from "./shared.js";
 
-ready();
-
 let provider = null;
 let account = null;
 
-window.addEventListener("DOMContentLoaded", () => {
-  setupWallet();
+window.addEventListener("DOMContentLoaded", async () => {
   document.getElementById("connect-btn")?.addEventListener("click", connectWallet);
   document.getElementById("approve-btn")?.addEventListener("click", approveUSDC);
   document.getElementById("pass-form")?.addEventListener("submit", buyPass);
   document.getElementById("book-form")?.addEventListener("submit", book);
+  await setupWallet();
+  await ready();
 });
 
 async function setupWallet() {


### PR DESCRIPTION
## Summary
- Guard `sdk.actions.ready` to run only once
- Invoke `ready()` after DOMContentLoaded and UI setup across app scripts

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fb88dfc8832abfbec6b68b62a828