### PR TITLE
fix: load ABIs with fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,10 +133,10 @@
         if (!from) throw new Error('No wallet account connected.');
         await ensureArbitrum(p);
 
-        // Lazy imports: these won’t block ready/splash
-        const [{ default: r3ntAbi }, { default: erc20Abi }, { R3NT_ADDRESS, USDC_ADDRESS }] = await Promise.all([
-          import('./js/abi/r3nt.json', { assert: { type: 'json' } }),
-          import('./js/abi/USDC.json', { assert: { type: 'json' } }),
+        // Lazy-load ABIs via fetch to avoid JSON module support issues
+        const [r3ntAbi, erc20Abi, { R3NT_ADDRESS, USDC_ADDRESS }] = await Promise.all([
+          fetch('./js/abi/r3nt.json').then(r => r.json()),
+          fetch('./js/abi/USDC.json').then(r => r.json()),
           import('./js/config.js'),
         ]);
 


### PR DESCRIPTION
## Summary
- use fetch to load ABI JSON instead of dynamic import

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a75b47a2a4832ab2e22d9bf0ee4334