### PR TITLE
Add QuickAuth FID test link

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <button id="buy" disabled>Buy View Pass (0.25 USDC)</button>
   <div id="status">Loading…</div>
   <p><a href="landlord.html">Landlord: Create Listing</a></p>
+  <p><a href="FIDTest.html">QuickAuth FID Test</a></p>
 
   <!-- 1) READY FIRST: tiny module; no other imports. -->
   <script type="module">


### PR DESCRIPTION
## Summary
- add landing page link to FIDTest QuickAuth page for verifying FID retrieval

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa823bfacc832ab14d5da93c3940ca