### PR TITLE
Fix cast hash padding to bytes32

### DIFF
--- a/js/tools.js
+++ b/js/tools.js
@@ -48,7 +48,8 @@ export function toBytes32FromCastHash(hex20or32) {
   if (/^0x[0-9a-fA-F]{64}$/.test(h)) return h;
 
   // 20-byte -> pad 12 bytes (24 hex chars) of zeros on the left
-  return '0x' + '0'.repeat(24 * 2) + h.slice(2);
+  // Each "00" represents one byte, so repeat 24 hex chars to add 12 bytes
+  return '0x' + '0'.repeat(24) + h.slice(2);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Correct 20-byte cast hash padding logic so `toBytes32FromCastHash` returns a valid bytes32 string

## Testing
- `node --input-type=module -e "import('./js/tools.js').then(m=>{const x=m.toBytes32FromCastHash('0x589575303ad91f377ac1cfae6d87a9dd16e0196b'); console.log('len',x.length);});"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8b44b534832a8eb2c63451b60da7