### PR TITLE
feat: add cosigner support and deposit admin page

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>r3nt — Admin</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; max-width: 460px; margin: 0 auto; padding: 16px 16px 40px; }
+    h1 { font-size: 1.25rem; margin: 8px 0 12px; }
+    .row { display: flex; gap: 10px; }
+    label { display: block; font-size: .9rem; margin: 10px 0 6px; }
+    input, textarea { width: 100%; padding: 10px 12px; border: 1px solid #d0d7de; border-radius: 8px; font-size: .95rem; }
+    textarea { height: 60px; }
+    button { width: 100%; padding: 12px 16px; border: 0; border-radius: 10px; font-weight: 700; cursor: pointer; }
+    button:disabled { opacity: .6; cursor: not-allowed; }
+    #connect { background: #1f6feb; color:#fff; margin:8px 0; }
+    #propose { background: #10b981; color:#fff; margin:8px 0; }
+    #sign { background: #6366f1; color:#fff; margin:8px 0; }
+    #confirm { background: #f97316; color:#fff; margin:8px 0; }
+    #status { min-height:22px; margin-top:10px; font-size:.95rem; color:#444; }
+    .muted { color:#666; }
+  </style>
+</head>
+<body>
+  <h1>r3nt — Deposit Admin</h1>
+  <div id="contextBar" class="muted">Starting…</div>
+  <button id="connect" disabled>Connect Wallet</button>
+  <label>Booking ID
+    <input id="bookingId" inputmode="numeric" />
+  </label>
+  <div class="row">
+    <label>To Tenant (USDC)
+      <input id="amtTenant" inputmode="decimal" value="0" />
+    </label>
+    <label>To Landlord (USDC)
+      <input id="amtLandlord" inputmode="decimal" value="0" />
+    </label>
+  </div>
+  <button id="propose" disabled>Propose Split</button>
+  <button id="sign" disabled>Sign Release</button>
+  <label>Landlord Signature
+    <textarea id="sigLandlord" readonly></textarea>
+  </label>
+  <label>Platform Signature
+    <textarea id="sigPlatform" readonly></textarea>
+  </label>
+  <button id="confirm" disabled>Confirm Release</button>
+  <div id="status"></div>
+  <script type="module" src="./js/admin.js"></script>
+</body>
+</html>

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,166 @@
+import { sdk } from 'https://esm.sh/@farcaster/miniapp-sdk';
+import { createPublicClient, http, encodeFunctionData, parseUnits, getAddress, keccak256, encodePacked, stringToHex, concatHex } from 'https://esm.sh/viem@2.9.32';
+import { arbitrum } from 'https://esm.sh/viem/chains';
+
+// -------------------- Config --------------------
+const ARBITRUM_HEX   = '0xa4b1';
+const R3NT_ADDRESS   = '0x18Af5B8fFA27B8300494Aa1a8c4F6AE4ee087029';
+const USDC_DECIMALS  = 6;
+const RELEASE_PREFIX = stringToHex('DEPOSIT_RELEASE', { size: 32 });
+
+// Minimal ABIs
+const r3ntAbi = await fetch('./js/abi/r3nt.json').then(r => r.json()).then(j => j.abi);
+const listingAbi = [
+  { type:'function', name:'tenant',       stateMutability:'view', inputs:[], outputs:[{type:'address'}] },
+  { type:'function', name:'landlord',     stateMutability:'view', inputs:[], outputs:[{type:'address'}] },
+  { type:'function', name:'propTenant',   stateMutability:'view', inputs:[], outputs:[{type:'uint96'}] },
+  { type:'function', name:'propLandlord', stateMutability:'view', inputs:[], outputs:[{type:'uint96'}] },
+  { type:'function', name:'nonce',        stateMutability:'view', inputs:[], outputs:[{type:'uint256'}] },
+];
+
+// -------------------- UI --------------------
+const els = {
+  contextBar: document.getElementById('contextBar'),
+  connect:    document.getElementById('connect'),
+  bookingId:  document.getElementById('bookingId'),
+  amtTenant:  document.getElementById('amtTenant'),
+  amtLandlord:document.getElementById('amtLandlord'),
+  propose:    document.getElementById('propose'),
+  sign:       document.getElementById('sign'),
+  sigLandlord:document.getElementById('sigLandlord'),
+  sigPlatform:document.getElementById('sigPlatform'),
+  confirm:    document.getElementById('confirm'),
+  status:     document.getElementById('status'),
+};
+const info = (t) => els.status.textContent = t;
+
+// -------------------- Boot --------------------
+let provider;
+const pub = createPublicClient({ chain: arbitrum, transport: http('https://arb1.arbitrum.io/rpc') });
+(async () => {
+  try { await sdk.actions.ready(); } catch {}
+  try {
+    const { token } = await sdk.quickAuth.getToken();
+    const [, payloadB64] = token.split('.');
+    const payloadJson = JSON.parse(atob(payloadB64.replace(/-/g, '+').replace(/_/g, '/')));
+    els.contextBar.textContent = `FID: ${payloadJson.sub} · Signed in`;
+  } catch {
+    els.contextBar.textContent = 'QuickAuth failed. Open inside a Farcaster client.';
+    return;
+  }
+  els.connect.disabled = false;
+})();
+
+async function ensureArbitrum(p) {
+  const id = await p.request({ method:'eth_chainId' });
+  if (id !== ARBITRUM_HEX) {
+    try {
+      await p.request({ method:'wallet_switchEthereumChain', params:[{ chainId: ARBITRUM_HEX }] });
+    } catch {
+      await p.request({ method:'wallet_addEthereumChain', params:[{ chainId: ARBITRUM_HEX, chainName:'Arbitrum One', nativeCurrency:{ name:'Ether', symbol:'ETH', decimals:18 }, rpcUrls:['https://arb1.arbitrum.io/rpc'], blockExplorerUrls:['https://arbiscan.io'] }] });
+    }
+  }
+}
+
+els.connect.onclick = async () => {
+  try {
+    provider = await sdk.wallet.getEthereumProvider();
+    await provider.request({ method:'eth_requestAccounts' });
+    await ensureArbitrum(provider);
+    els.connect.textContent = 'Wallet Connected';
+    els.connect.style.background = '#10b981';
+    els.propose.disabled = false;
+    els.sign.disabled = false;
+    els.confirm.disabled = false;
+    info('Wallet ready.');
+  } catch (e) {
+    info(e?.message || 'Wallet connection failed.');
+  }
+};
+
+function parseDec6(s) {
+  const v = String(s ?? '').trim();
+  if (v === '') throw new Error('Missing numeric value.');
+  if (!/^\d+(\.\d{1,6})?$/.test(v)) throw new Error('Use up to 6 decimals.');
+  return parseUnits(v, USDC_DECIMALS);
+}
+
+els.propose.onclick = async () => {
+  try {
+    if (!provider) throw new Error('Connect wallet first.');
+    const [from] = await provider.request({ method:'eth_accounts' }) || [];
+    if (!from) throw new Error('No wallet account.');
+    await ensureArbitrum(provider);
+    const bookingId = BigInt(els.bookingId.value);
+    const toTenant = parseDec6(els.amtTenant.value);
+    const toLandlord = parseDec6(els.amtLandlord.value);
+    const data = encodeFunctionData({
+      abi: r3ntAbi,
+      functionName: 'proposeDepositSplit',
+      args: [bookingId, toTenant, toLandlord]
+    });
+    const txHash = await provider.request({ method:'eth_sendTransaction', params:[{ from, to:R3NT_ADDRESS, data }] });
+    info(`Propose tx sent: ${txHash}`);
+  } catch (e) {
+    info(`Error: ${e?.message || e}`);
+  }
+};
+
+async function buildReleaseHash(bookingId) {
+  const b = await pub.readContract({ address:R3NT_ADDRESS, abi:r3ntAbi, functionName:'getBooking', args:[bookingId] });
+  const listing = await pub.readContract({ address:R3NT_ADDRESS, abi:r3ntAbi, functionName:'getListing', args:[b.listingId] });
+  const vault = listing.vault;
+  const [tenant, landlord, propTenant, propLandlord, nonce] = await Promise.all([
+    pub.readContract({ address:vault, abi:listingAbi, functionName:'tenant' }),
+    pub.readContract({ address:vault, abi:listingAbi, functionName:'landlord' }),
+    pub.readContract({ address:vault, abi:listingAbi, functionName:'propTenant' }),
+    pub.readContract({ address:vault, abi:listingAbi, functionName:'propLandlord' }),
+    pub.readContract({ address:vault, abi:listingAbi, functionName:'nonce' })
+  ]);
+  return keccak256(encodePacked(
+    ['bytes32','address','address','address','uint96','uint96','uint256'],
+    [RELEASE_PREFIX, vault, tenant, landlord, propTenant, propLandlord, nonce]
+  ));
+}
+
+els.sign.onclick = async () => {
+  try {
+    if (!provider) throw new Error('Connect wallet first.');
+    const [from] = await provider.request({ method:'eth_accounts' }) || [];
+    if (!from) throw new Error('No wallet account.');
+    await ensureArbitrum(provider);
+    const bookingId = BigInt(els.bookingId.value);
+    const hash = await buildReleaseHash(bookingId);
+    const sig = await provider.request({ method:'eth_sign', params:[from, hash] });
+    // store depending on role
+    const addr = getAddress(from);
+    if (!els.sigLandlord.value) {
+      els.sigLandlord.value = sig;
+    } else if (!els.sigPlatform.value) {
+      els.sigPlatform.value = sig;
+    }
+    info('Signature generated.');
+  } catch (e) {
+    info(`Error: ${e?.message || e}`);
+  }
+};
+
+els.confirm.onclick = async () => {
+  try {
+    if (!provider) throw new Error('Connect wallet first.');
+    const [from] = await provider.request({ method:'eth_accounts' }) || [];
+    if (!from) throw new Error('No wallet account.');
+    await ensureArbitrum(provider);
+    const bookingId = BigInt(els.bookingId.value);
+    const sig1 = els.sigLandlord.value.trim();
+    const sig2 = els.sigPlatform.value.trim();
+    if (!sig1 || !sig2) throw new Error('Both signatures required.');
+    const combined = concatHex([sig1, sig2]);
+    const data = encodeFunctionData({ abi:r3ntAbi, functionName:'confirmDepositRelease', args:[bookingId, combined] });
+    const txHash = await provider.request({ method:'eth_sendTransaction', params:[{ from, to:R3NT_ADDRESS, data }] });
+    info(`Confirm tx sent: ${txHash}`);
+  } catch (e) {
+    info(`Error: ${e?.message || e}`);
+  }
+};
+

--- a/landlord.html
+++ b/landlord.html
@@ -93,7 +93,7 @@
   <div class="muted">
     <small class="mono">
       Signers are fixed: landlord + platform (hidden).
-      <span id="signerMode" class="pill">Single-signer (dev stage)</span>
+      <span id="signerMode" class="pill">2-of-2 (landlord + platform)</span>
     </small>
   </div>
 
@@ -102,7 +102,7 @@
 
   <script type="module">
     import { sdk } from 'https://esm.sh/@farcaster/miniapp-sdk';
-    import { createPublicClient, http, encodeFunctionData, parseUnits } from 'https://esm.sh/viem@2.9.32';
+    import { createPublicClient, http, encodeFunctionData, parseUnits, getAddress } from 'https://esm.sh/viem@2.9.32';
     import { arbitrum } from 'https://esm.sh/viem/chains';
     import { normalizeCastInputToBytes32, latLonToGeohash } from './js/tools.js';
 
@@ -112,9 +112,9 @@
     const USDC_ADDRESS   = '0xaf88d065e77c8cc2239327c5edb3a432268e5831';
     const USDC_DECIMALS  = 6;
 
-    // Multisig (kept simple here)
-    const APP_SIGNERS_BYTES = []; // add ERC-7913 identities later
-    const APP_THRESHOLD = 1n;
+    // 2-of-2 cosigners (landlord + platform)
+    const PLATFORM_SIGNER = '0xYourPlatformOpsKey...'; // <-- set this to your ops EOA on Arbitrum
+    const encodeErc7913Ecdsa = (addr) => '0x00' + getAddress(addr).slice(2);
 
     // Minimal ERC-20 ABI surface
     const erc20Abi = [
@@ -239,6 +239,12 @@
         const [from] = await provider.request({ method:'eth_accounts' }) || [];
         if (!from) throw new Error('No wallet account connected.');
         await ensureArbitrum(provider);
+        const landlordAddr = getAddress(from);
+        const signersBytes = [
+          encodeErc7913Ecdsa(landlordAddr),
+          encodeErc7913Ecdsa(PLATFORM_SIGNER),
+        ];
+        const threshold = 2n;
 
         let castHashBytes32;
         try {
@@ -283,8 +289,8 @@
             fidBig,          // bigint from QuickAuth
             castHashBytes32,
             title, shortDesc,
-            APP_SIGNERS_BYTES,
-            APP_THRESHOLD
+            signersBytes,
+            threshold
           ]
         });
 


### PR DESCRIPTION
## Summary
- require landlord and platform 2-of-2 signing when creating a listing
- add admin page for proposing and confirming deposit releases

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8e259a00832aaa5840ae8623a8ab