### PR TITLE
Call ready in index and add beta note

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
     header{display:flex;align-items:center;justify-content:space-between;margin-bottom:16px}
     .brand{font-weight:800;letter-spacing:.3px}
     .pill{display:inline-block;padding:2px 10px;border-radius:999px;background:#e6f4ff;color:#075985;font-weight:600;font-size:.8rem}
+    .beta-note{font-size:.9rem;margin:-12px 0 16px}
     .hero{display:grid;grid-template-columns:1fr;gap:18px;padding:22px;border:1px solid var(--stroke);border-radius:16px;background:var(--card)}
     h1{font-size:1.8rem;line-height:1.2;margin:0}
     p.lead{font-size:1.05rem;color:var(--muted);margin:.25rem 0 0}
@@ -60,6 +61,8 @@
       <div class="brand">r3nt by SQMU</div>
       <span class="pill">Farcaster Mini App</span>
     </header>
+
+    <div class="muted beta-note">Early beta — under development.</div>
 
     <div class="hero">
       <div>
@@ -128,5 +131,13 @@
       r3nt is a product of SQMU. USDC is the standard settlement currency. Network: Arbitrum.
     </footer>
   </div>
+
+  <script type="module">
+    import { sdk } from 'https://esm.sh/@farcaster/miniapp-sdk';
+    (async () => {
+      try { await sdk.actions.ready(); } catch {}
+      setTimeout(() => { try { sdk.actions.ready(); } catch {} }, 800);
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add beta status note below the header
- call `sdk.actions.ready()` on load to hide splash screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aba163dc28832a959c0727d0eef57f