### PR TITLE
Encode query params into Farcaster embed URL

### DIFF
--- a/landlord.html
+++ b/landlord.html
@@ -257,9 +257,17 @@
 
         // 1) Compose the landlord's canonical cast and capture the hash
         info('Open composer… Post your listing cast.');
+        const qs = [
+          'draft=1',
+          `title=${encodeURIComponent(title)}`,
+          `shortDesc=${encodeURIComponent(shortDesc)}`,
+          `lat=${encodeURIComponent(String(lat))}`,
+          `lon=${encodeURIComponent(String(lon))}`
+        ].join('&');
+        const embedUrl = `https://r3nt.sqmu.net/index.html?${qs}`;
         const compose = await sdk.actions.composeCast({
           text: `🏠 ${title}\n${shortDesc}\n\nView & book in r3nt ↓`,
-          embeds: [ 'https://r3nt.sqmu.net/index.html' ],
+          embeds: [ embedUrl ],
           close: false
         });
         if (!compose || !compose.cast) throw new Error('Cast was not posted.');


### PR DESCRIPTION
## Summary
- Build embed URL for listing cast with query string including draft flag, title, description, and coordinates
- URL-encode all dynamic values before composing cast

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node` sample to generate URL with encoded params

------
https://chatgpt.com/codex/tasks/task_e_68abbc606db8832a9b43949e5ba97b71