### PR TITLE
fix: set white background for landlord and tenant pages

### DIFF
--- a/landlord.html
+++ b/landlord.html
@@ -22,7 +22,8 @@
   }' />
 
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; max-width: 460px; margin: 0 auto; padding: 16px 16px 40px; }
+    :root { --fg:#0f172a; --bg:#ffffff; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; max-width: 460px; margin: 0 auto; padding: 16px 16px 40px; background: var(--bg); color: var(--fg); }
     h1 { font-size: 1.25rem; margin: 8px 0 12px; }
     .row { display: flex; gap: 10px; }
     label { display: block; font-size: .9rem; margin: 10px 0 6px; }

--- a/tenant.html
+++ b/tenant.html
@@ -8,7 +8,8 @@
   <meta name="fc:miniapp" content='{"version":"1","imageUrl":"https://r3nt.sqmu.net/assets/icon.png","button":{"title":"Open r3nt","action":{"type":"launch_miniapp","name":"r3nt","url":"https://r3nt.sqmu.net/index.html","splashImageUrl":"https://r3nt.sqmu.net/assets/splashscreen.png","splashBackgroundColor":"#FFFFFF"}}}' />
 
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; max-width: 460px; margin: 0 auto; padding: 20px; }
+    :root { --fg:#0f172a; --bg:#ffffff; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; max-width: 460px; margin: 0 auto; padding: 20px; background: var(--bg); color: var(--fg); }
     button { width: 100%; padding: 12px 16px; border: 0; border-radius: 8px; font-weight: 600; cursor: pointer; }
     button:disabled { opacity: .6; cursor: not-allowed; }
     #connect { background: #1f6feb; color: #fff; }


### PR DESCRIPTION
## Summary
- align landlord and tenant page styles with index by defining foreground/background colors

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abc1c5f2b8832aa7fb5dd0bd4d4a63