### PR TITLE
feat: view cast from listing card

### DIFF
--- a/tenant.html
+++ b/tenant.html
@@ -86,9 +86,13 @@
       }
     }
 
-    async function openCast(hash){
-      try { await sdk.actions.viewCast({ hash, close:false }); }
-      catch { /* fallback: open in Warpcast */ window.open(bytes32ToCastUrl(hash), '_blank', 'noopener'); }
+    async function openCast(hash /* canonical 0x + 64 hex */){
+      try {
+        await sdk.actions.viewCast({ hash });
+      } catch {
+        // fallback: open in Warpcast
+        window.open(bytes32ToCastUrl(hash), '_blank');
+      }
     }
 
     async function loadListings(){


### PR DESCRIPTION
## Summary
- use sdk.actions.viewCast to open listing casts with Warpcast fallback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abcc28a83c832aa509597b139ebc45