### PR TITLE
Trim cast hash before invoking viewCast

### DIFF
--- a/js/tools.js
+++ b/js/tools.js
@@ -171,16 +171,24 @@ export function normalizeCastInputToBytes32(inputUrlOrHex) {
 }
 
 /**
+ * Convert a stored bytes32 cast hash back into a 20-byte Farcaster cast hash.
+ * @param {string} castHash32 0x + 64 hex
+ * @returns {string} 0x + 40 hex cast hash
+ */
+export function bytes32ToCastHash(castHash32) {
+  const h = String(castHash32 || '');
+  if (!/^0x[0-9a-fA-F]{64}$/.test(h)) {
+    throw new Error('Expected 32-byte hex for cast.');
+  }
+  return '0x' + h.slice(-40);
+}
+
+/**
  * Convert a stored bytes32 cast hash back into a canonical Warpcast URL.
  * Assumes the original Farcaster hash was 20 bytes left-padded to 32 bytes.
  * @param {string} castHash32 0x + 64 hex
  * @returns {string} Warpcast URL: https://warpcast.com/~/casts/0x...
  */
 export function bytes32ToCastUrl(castHash32) {
-  const h = String(castHash32 || '');
-  if (!/^0x[0-9a-fA-F]{64}$/.test(h)) {
-    throw new Error('Expected 32-byte hex for cast.');
-  }
-  const cast20 = '0x' + h.slice(-40);
-  return `https://warpcast.com/~/casts/${cast20}`;
+  return `https://warpcast.com/~/casts/${bytes32ToCastHash(castHash32)}`;
 }

--- a/tenant.html
+++ b/tenant.html
@@ -49,7 +49,7 @@
     import { sdk } from 'https://esm.sh/@farcaster/miniapp-sdk';
     import { encodeFunctionData, parseUnits, erc20Abi, createPublicClient, http } from 'https://esm.sh/viem@2.9.32';
     import { arbitrum } from 'https://esm.sh/viem/chains';
-    import { bytes32ToCastUrl } from './js/tools.js';
+    import { bytes32ToCastUrl, bytes32ToCastHash } from './js/tools.js';
 
     const els = {
       connect: document.getElementById('connect'),
@@ -86,9 +86,14 @@
       }
     }
 
-    async function openCast(hash){
-      try { await sdk.actions.viewCast({ hash, close:false }); }
-      catch { /* fallback: open in Warpcast */ window.open(bytes32ToCastUrl(hash), '_blank', 'noopener'); }
+    async function openCast(hash32 /* bytes32 from contract */){
+      const cast20 = bytes32ToCastHash(hash32);
+      try {
+        await sdk.actions.viewCast({ hash: cast20 });
+      } catch {
+        // fallback: open in Warpcast
+        window.open(bytes32ToCastUrl(hash32), '_blank');
+      }
     }
 
     async function loadListings(){


### PR DESCRIPTION
## Summary
- normalize bytes32 cast hashes to 20-byte format before calling `sdk.actions.viewCast`
- add `bytes32ToCastHash` helper and reuse it for Warpcast fallback URLs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abcc28a83c832aa509597b139ebc45