### PR TITLE
Add midnight alignment checks for BookingRegistry ranges

### DIFF
--- a/contracts/BookingRegistry.sol
+++ b/contracts/BookingRegistry.sol
@@ -47,6 +47,7 @@ contract BookingRegistry is
         nonReentrant
     {
         require(endTsUTC > startTsUTC, "range");
+        require(startTsUTC % DAY == 0 && endTsUTC % DAY == 0, "midnight");
         (uint32 sDay, uint32 eDay) = _normalizeTsToDays(startTsUTC, endTsUTC);
         _requireFree(listing, sDay, eDay);
         _mark(listing, sDay, eDay, true);
@@ -60,6 +61,7 @@ contract BookingRegistry is
         nonReentrant
     {
         require(endTsUTC > startTsUTC, "range");
+        require(startTsUTC % DAY == 0 && endTsUTC % DAY == 0, "midnight");
         (uint32 sDay, uint32 eDay) = _normalizeTsToDays(startTsUTC, endTsUTC);
         _mark(listing, sDay, eDay, false);
         emit Released(listing, msg.sender, sDay, eDay);


### PR DESCRIPTION
## Summary
- ensure `reserve` and `release` only accept midnight-aligned UTC timestamps

## Testing
- `forge build` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2ef13f88832aa9e4b60b34b62a92