### PR TITLE
Ensure safe month start cast

### DIFF
--- a/contracts/BookingRegistry.sol
+++ b/contracts/BookingRegistry.sol
@@ -135,7 +135,16 @@ contract BookingRegistry is
 
     // Build mask for portion of [sDay, eDay) that lies in (year, month)
     function _maskForMonthSpan(uint16 year, uint8 month, uint32 sDay, uint32 eDay) internal pure returns (uint32) {
-        uint32 monthStart = uint32(_daysFromCivil(int256(year), int256(month), int256(1)));
+        int256 mStartInt = _daysFromCivil(
+            int256(uint256(year)),
+            int256(uint256(month)),
+            1
+        );
+        require(
+            mStartInt >= 0 && mStartInt <= int256(uint256(type(uint32).max)),
+            "range"
+        );
+        uint32 monthStart = uint32(uint256(mStartInt));
         uint8 dim = _daysInMonth(year, month);
         uint32 monthEndExcl = monthStart + dim; // exclusive
 


### PR DESCRIPTION
## Summary
- use uint256 intermediary when converting year and month for `_daysFromCivil`
- validate month start is non-negative and fits within `uint32`

## Testing
- `npx solcjs --base-path . --include-path node_modules --standard-json < /tmp/solc-input.json`


------
https://chatgpt.com/codex/tasks/task_e_68bdd9e53d40832a8e064215d251c7eb