### PR TITLE
chore: remove unused vars in BookingRegistry

### DIFF
--- a/contracts/BookingRegistry.sol
+++ b/contracts/BookingRegistry.sol
@@ -105,8 +105,8 @@ contract BookingRegistry is
     }
 
     function _isFree(address L, uint32 sDay, uint32 eDay) internal view returns (bool) {
-        (uint16 yS, uint8 mS, uint8 dS) = _civilFromDays(int256(uint256(sDay)));
-        (uint16 yE, uint8 mE, uint8 dE) = _civilFromDays(int256(uint256(eDay - 1))); // last occupied day
+        (uint16 yS, uint8 mS, ) = _civilFromDays(int256(uint256(sDay)));
+        (uint16 yE, uint8 mE, ) = _civilFromDays(int256(uint256(eDay - 1))); // last occupied day
         uint32 ymS = uint32(yS) * 12 + (mS - 1);
         uint32 ymE = uint32(yE) * 12 + (mE - 1);
 


### PR DESCRIPTION
## Summary
- clean up unused variables in `_isFree` to silence compiler warnings

## Testing
- `npx --yes solc@0.8.26 --base-path . --include-path /tmp/oz/node_modules --bin contracts/BookingRegistry.sol` *(fails: Stack too deep; requires via-ir)*

------
https://chatgpt.com/codex/tasks/task_e_68bddbddb604832aa5e8e1b6d6c64106