### PR TITLE
Use deployed BookingRegistry contract address in front-end

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1,7 +1,7 @@
 import { sdk } from 'https://esm.sh/@farcaster/miniapp-sdk';
 import { createPublicClient, http, encodeFunctionData, parseUnits, getAddress, keccak256, encodePacked, stringToHex, concatHex } from 'https://esm.sh/viem@2.9.32';
 import { arbitrum } from 'https://esm.sh/viem/chains';
-import { R3NT_ADDRESS, RPC_URL } from './config.js';
+import { R3NT_ADDRESS, RPC_URL, REGISTRY_ADDRESS } from './config.js';
 
 // -------------------- Config --------------------
 const ARBITRUM_HEX   = '0xa4b1';
@@ -34,6 +34,7 @@ const els = {
   setRegistry:document.getElementById('setRegistry'),
   status:     document.getElementById('status'),
 };
+els.registry.value = REGISTRY_ADDRESS;
 const info = (t) => els.status.textContent = t;
 
 // -------------------- Boot --------------------

--- a/landlord.html
+++ b/landlord.html
@@ -128,7 +128,7 @@
     import { createPublicClient, http, encodeFunctionData, parseUnits, getAddress } from 'https://esm.sh/viem@2.9.32';
     import { arbitrum } from 'https://esm.sh/viem/chains';
     import { latLonToGeohash, isHex20or32, toBytes32FromCastHash } from './js/tools.js';
-    import { R3NT_ADDRESS, USDC_ADDRESS, PLATFORM_ADDRESS, RPC_URL } from './js/config.js';
+    import { R3NT_ADDRESS, USDC_ADDRESS, PLATFORM_ADDRESS, RPC_URL, REGISTRY_ADDRESS } from './js/config.js';
 
     // -------------------- Config --------------------
     const ARBITRUM_HEX   = '0xa4b1';
@@ -197,11 +197,8 @@
 
     async function loadBooking(){
       if (!bookingAbi) {
-        if (!r3ntAbi) {
-          r3ntAbi = await fetch('./js/abi/r3nt.json').then(r => r.json()).then(j => j.abi);
-        }
         bookingAbi = await fetch('./js/abi/BookingRegistry.json').then(r => r.json()).then(j => j.abi);
-        bookingAddr = await pub.readContract({ address: R3NT_ADDRESS, abi: r3ntAbi, functionName: 'bookingRegistry' });
+        bookingAddr = REGISTRY_ADDRESS;
       }
     }
 

--- a/tenant.html
+++ b/tenant.html
@@ -96,7 +96,7 @@
         ]);
         pub = createPublicClient({ chain: arbitrum, transport: http(cfg.RPC_URL || 'https://arb1.arbitrum.io/rpc') });
         feeBps = await pub.readContract({ address: cfg.R3NT_ADDRESS, abi: r3ntAbi, functionName: 'feeBps' });
-        bookingAddr = await pub.readContract({ address: cfg.R3NT_ADDRESS, abi: r3ntAbi, functionName: 'bookingRegistry' });
+        bookingAddr = cfg.REGISTRY_ADDRESS;
       }
     }
 


### PR DESCRIPTION
## Summary
- Load BookingRegistry contract at deployed address from config
- Prefill admin interface with current BookingRegistry address

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bde1c9ab28832aa7060b1c2a821f5a