### PR TITLE
Remove booking registry from admin page

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -20,7 +20,6 @@
     #confirm { background: #f97316; color:#fff; margin:8px 0; }
     #status { min-height:22px; margin-top:10px; font-size:.95rem; color:#444; }
     .muted { color:#666; }
-    .divider { height:1px; background:#eee; margin:14px 0; }
     nav { margin-bottom:16px; }
     nav a { margin-right:10px; color:#1f6feb; text-decoration:none; font-weight:600; }
   </style>
@@ -55,12 +54,6 @@
     <textarea id="sigPlatform" readonly></textarea>
   </label>
   <button id="confirm" disabled>Confirm Release</button>
-  <div class="divider"></div>
-  <h2>Registry</h2>
-  <label>BookingRegistry Address
-    <input id="registryAddr" placeholder="0x..." />
-  </label>
-  <button id="setRegistry" disabled>Set Booking Registry</button>
   <div id="status"></div>
   <script type="module" src="./js/admin.js"></script>
 </body>

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,7 +1,7 @@
 import { sdk } from 'https://esm.sh/@farcaster/miniapp-sdk';
-import { createPublicClient, http, encodeFunctionData, parseUnits, getAddress, keccak256, encodePacked, stringToHex, concatHex } from 'https://esm.sh/viem@2.9.32';
+import { createPublicClient, http, encodeFunctionData, parseUnits, keccak256, encodePacked, stringToHex, concatHex } from 'https://esm.sh/viem@2.9.32';
 import { arbitrum } from 'https://esm.sh/viem/chains';
-import { R3NT_ADDRESS, RPC_URL, REGISTRY_ADDRESS } from './config.js';
+import { R3NT_ADDRESS, RPC_URL } from './config.js';
 
 // -------------------- Config --------------------
 const ARBITRUM_HEX   = '0xa4b1';
@@ -30,11 +30,8 @@ const els = {
   sigLandlord:document.getElementById('sigLandlord'),
   sigPlatform:document.getElementById('sigPlatform'),
   confirm:    document.getElementById('confirm'),
-  registry:   document.getElementById('registryAddr'),
-  setRegistry:document.getElementById('setRegistry'),
   status:     document.getElementById('status'),
 };
-els.registry.value = REGISTRY_ADDRESS;
 const info = (t) => els.status.textContent = t;
 
 // -------------------- Boot --------------------
@@ -75,7 +72,6 @@ els.connect.onclick = async () => {
     els.propose.disabled = false;
     els.sign.disabled = false;
     els.confirm.disabled = false;
-    els.setRegistry.disabled = false;
     info('Wallet ready.');
   } catch (e) {
     info(e?.message || 'Wallet connection failed.');
@@ -137,7 +133,6 @@ els.sign.onclick = async () => {
     const hash = await buildReleaseHash(bookingId);
     const sig = await provider.request({ method:'eth_sign', params:[from, hash] });
     // store depending on role
-    const addr = getAddress(from);
     if (!els.sigLandlord.value) {
       els.sigLandlord.value = sig;
     } else if (!els.sigPlatform.value) {
@@ -168,19 +163,4 @@ els.confirm.onclick = async () => {
   }
 };
 
-els.setRegistry.onclick = async () => {
-  try {
-    if (!provider) throw new Error('Connect wallet first.');
-    const [from] = await provider.request({ method:'eth_accounts' }) || [];
-    if (!from) throw new Error('No wallet account.');
-    await ensureArbitrum(provider);
-    const addr = els.registry.value.trim();
-    if (!addr) throw new Error('Enter address.');
-    const data = encodeFunctionData({ abi:r3ntAbi, functionName:'setBookingRegistry', args:[addr] });
-    const txHash = await provider.request({ method:'eth_sendTransaction', params:[{ from, to:R3NT_ADDRESS, data }] });
-    info(`Registry set tx: ${txHash}`);
-  } catch (e) {
-    info(`Error: ${e?.message || e}`);
-  }
-};
 


### PR DESCRIPTION
## Summary
- remove booking registry address section from admin interface
- drop related configuration and registry setter logic from admin script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bde3985638832aa9960f05ad4a2e4a