### PR TITLE
feat: support rent tokenisation requests

### DIFF
--- a/contracts/r3nt-SQMU.sol
+++ b/contracts/r3nt-SQMU.sol
@@ -42,6 +42,39 @@ contract R3NTSQMU is ERC1155Supply, AccessControl {
         uint64  end;           // UTC midnight
     }
 
+    /// @notice Request to tokenise rent for a booking
+    /// @dev `landlord` indicates if the proposer is the landlord (tokenising
+    ///      future rental income) or tenant (tokenising an upfront payment).
+    struct TokenizationRequest {
+        address proposer;
+        bool landlord;
+        uint256 amount;   // amount of tokens to mint
+        uint16 feeBps;    // platform fee on the tokenised amount
+        uint16 rateBps;   // periodic rate in basis points
+        uint8  frequency; // 1 = weekly, 2 = monthly
+        bool approved;
+    }
+
+    mapping(uint256 => TokenizationRequest) public tokenizationRequests;
+
+    event TokenizationProposed(
+        uint256 indexed bookingId,
+        address indexed proposer,
+        bool landlord,
+        uint256 amount,
+        uint16 feeBps,
+        uint16 rateBps,
+        uint8 frequency
+    );
+
+    event TokenizationApproved(
+        uint256 indexed bookingId,
+        address indexed proposer,
+        uint256 amount,
+        uint16 feeBps,
+        uint16 rateBps
+    );
+
     mapping(uint256 => Booking) public bookings;
     uint256 public nextId;
 
@@ -92,6 +125,83 @@ contract R3NTSQMU is ERC1155Supply, AccessControl {
         });
     }
 
+    /// @notice Propose tokenisation of rent for a booking
+    /// @param bookingId The booking to tokenise
+    /// @param amount Amount of tokens to mint upon approval
+    /// @param feeBps_ Proposed platform fee in basis points
+    /// @param rateBps_ Proposed periodic rate in basis points
+    /// @param frequency 1 = weekly, 2 = monthly
+    function proposeTokenization(
+        uint256 bookingId,
+        uint256 amount,
+        uint16 feeBps_,
+        uint16 rateBps_,
+        uint8 frequency
+    ) external {
+        Booking memory b = bookings[bookingId];
+        require(b.tenant != address(0), "invalid booking");
+
+        bool isLandlord;
+        if (msg.sender == b.landlord) {
+            isLandlord = true;
+        } else if (msg.sender == b.tenant) {
+            isLandlord = false;
+        } else {
+            revert("unauthorized");
+        }
+
+        TokenizationRequest storage r = tokenizationRequests[bookingId];
+        require(r.proposer == address(0), "exists");
+
+        tokenizationRequests[bookingId] = TokenizationRequest({
+            proposer: msg.sender,
+            landlord: isLandlord,
+            amount: amount,
+            feeBps: feeBps_,
+            rateBps: rateBps_,
+            frequency: frequency,
+            approved: false
+        });
+
+        emit TokenizationProposed(
+            bookingId,
+            msg.sender,
+            isLandlord,
+            amount,
+            feeBps_,
+            rateBps_,
+            frequency
+        );
+    }
+
+    /// @notice Approve a tokenisation request and mint tokens
+    /// @param bookingId Booking identifier
+    /// @param feeBps_ Final platform fee in basis points
+    /// @param rateBps_ Final periodic rate in basis points
+    function approveTokenization(
+        uint256 bookingId,
+        uint16 feeBps_,
+        uint16 rateBps_
+    ) external onlyRole(R3NT_ROLE) {
+        TokenizationRequest storage r = tokenizationRequests[bookingId];
+        require(r.proposer != address(0), "no request");
+        require(!r.approved, "approved");
+
+        r.feeBps = feeBps_;
+        r.rateBps = rateBps_;
+        r.approved = true;
+
+        _mint(r.proposer, bookingId, r.amount, "");
+
+        emit TokenizationApproved(
+            bookingId,
+            r.proposer,
+            r.amount,
+            feeBps_,
+            rateBps_
+        );
+    }
+
     /// @notice Release booking and burn tokens after the stay concludes
     function conclude(uint256 bookingId) external {
         Booking memory b = bookings[bookingId];
@@ -100,6 +210,7 @@ contract R3NTSQMU is ERC1155Supply, AccessControl {
         registry.release(b.listing, b.start, b.end);
         _burn(b.tenant, bookingId, b.area);
         delete bookings[bookingId];
+        delete tokenizationRequests[bookingId];
     }
 }
 


### PR DESCRIPTION
## Summary
- add `TokenizationRequest` struct and mappings to track rent tokenisation proposals
- allow landlords or tenants to propose rent tokenisation terms
- let admins approve tokenisation and mint tokens for the booking

## Testing
- `npx --yes solc@0.8.26 --bin contracts/r3nt-SQMU.sol` *(fails: OpenZeppelin imports missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c5afe1f7e4832a87f1c9b662391b97