### PR TITLE
Update Ownable initializers with owner parameter

### DIFF
--- a/contracts/BookingRegistry.sol
+++ b/contracts/BookingRegistry.sol
@@ -74,10 +74,8 @@ contract BookingRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     function initialize(InitializeParams calldata params) external initializer {
         require(params.owner != address(0), "owner=0");
 
-        __Ownable_init();
+        __Ownable_init(params.owner);
         __UUPSUpgradeable_init();
-
-        _transferOwnership(params.owner);
 
         address initialPlatform = params.platform;
         platform = initialPlatform;

--- a/contracts/ListingFactory.sol
+++ b/contracts/ListingFactory.sol
@@ -72,13 +72,11 @@ contract ListingFactory is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         require(params.platform != address(0), "platform=0");
         require(params.implementation != address(0), "impl=0");
 
-        __Ownable_init();
+        __Ownable_init(params.owner);
         __UUPSUpgradeable_init();
 
         platform = params.platform;
         listingImplementation = params.implementation;
-
-        _transferOwnership(params.owner);
 
         emit PlatformUpdated(address(0), params.platform);
         emit ListingImplementationUpdated(address(0), params.implementation);

--- a/contracts/Platform.sol
+++ b/contracts/Platform.sol
@@ -128,7 +128,7 @@ contract Platform is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         require(params.owner != address(0), "owner=0");
         require(params.usdc != address(0), "usdc=0");
 
-        __Ownable_init();
+        __Ownable_init(params.owner);
         __UUPSUpgradeable_init();
 
         _setUsdc(params.usdc);
@@ -136,8 +136,6 @@ contract Platform is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         _setModules(params.listingFactory, params.bookingRegistry, params.sqmuToken);
         _setFees(params.tenantFeeBps, params.landlordFeeBps);
         _setListingPricing(params.listingCreationFee, params.viewPassPrice);
-
-        _transferOwnership(params.owner);
 
         emit PlatformInitialized(params.owner, params.usdc, params.treasury);
     }


### PR DESCRIPTION
## Summary
- pass the owner parameter into `__Ownable_init` for Platform, ListingFactory, and BookingRegistry
- remove the redundant `_transferOwnership` calls now that OZ v5 accepts the owner during initialization

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb482ea2bc832a96ef34f7c34ad0af