### PR TITLE
Refactor ListingFactory interface placement

### DIFF
--- a/contracts/ListingFactory.sol
+++ b/contracts/ListingFactory.sol
@@ -8,6 +8,26 @@ import {ClonesUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/Clone
 
 import {Platform} from "./Platform.sol";
 
+/// @dev Minimal interface for Listing clones.
+interface IListing {
+    function initialize(
+        address landlord,
+        address platform,
+        address bookingRegistry,
+        address sqmuToken,
+        uint256 fid,
+        bytes32 castHash,
+        bytes32 geohash,
+        uint8 geohashPrecision,
+        uint32 areaSqm,
+        uint256 baseDailyRate,
+        uint256 depositAmount,
+        uint64 minBookingNotice,
+        uint64 maxBookingWindow,
+        string calldata metadataURI
+    ) external;
+}
+
 /**
  * @title ListingFactory
  * @notice Deploys clone instances of the Listing contract and wires them to protocol modules.
@@ -16,26 +36,6 @@ import {Platform} from "./Platform.sol";
  */
 contract ListingFactory is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     using ClonesUpgradeable for address;
-
-    /// @dev Minimal interface for Listing clones.
-    interface IListing {
-        function initialize(
-            address landlord,
-            address platform,
-            address bookingRegistry,
-            address sqmuToken,
-            uint256 fid,
-            bytes32 castHash,
-            bytes32 geohash,
-            uint8 geohashPrecision,
-            uint32 areaSqm,
-            uint256 baseDailyRate,
-            uint256 depositAmount,
-            uint64 minBookingNotice,
-            uint64 maxBookingWindow,
-            string calldata metadataURI
-        ) external;
-    }
 
     // -------------------------------------------------
     // Storage


### PR DESCRIPTION
## Summary
- lift the minimal IListing interface declaration outside of the ListingFactory contract
- retain the ListingFactory create flow that casts freshly cloned listings to the interface for initialization

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbe2e67544832aa86f1c7133d0d3ad