### PR TITLE
Update config with placeholder contract addresses and ABIs

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,12 +1,28 @@
+import R3NTSQMUArtifact from './abi/r3nt-SQMU.json' assert { type: 'json' };
+import BookingRegistryArtifact from './abi/BookingRegistry.json' assert { type: 'json' };
+import ListingArtifact from './abi/Listing.json' assert { type: 'json' };
+import ListingFactoryArtifact from './abi/ListingFactory.json' assert { type: 'json' };
+import PlatformArtifact from './abi/Platform.json' assert { type: 'json' };
+
 export const CHAIN_ID = 42161; // Arbitrum One
-export const RPC_URL = "https://arb1.arbitrum.io/rpc";
+export const RPC_URL = 'https://arb1.arbitrum.io/rpc';
 
-export const R3NT_ADDRESS = "0x18Af5B8fFA27B8300494Aa1a8c4F6AE4ee087029";
-export const FACTORY_ADDRESS = "0x7c67FDcebc883C1BACd03Ee7483e8E6300F4Df51";
-export const USDC_ADDRESS = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
-export const PLATFORM_ADDRESS = "0x43F3f03d89290358034993aE3B3938D056D76De2";
-export const REGISTRY_ADDRESS = "0x813a224916CbB7968443770Dc93c41830c2E0980";
+export const USDC_ADDRESS = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
 
+export const R3NT_ADDRESS = '0xYourR3ntSQMUAddressHere'; // r3nt-SQMU (SQMU-R token)
+export const R3NT_ABI = R3NTSQMUArtifact.abi;
 
-export const APP_NAME = "r3nt";
-export const APP_DOMAIN = "r3nt.sqmu.net"; // origin used in EIP-712 domain if needed
+export const REGISTRY_ADDRESS = '0xYourBookingRegistryAddressHere'; // BookingRegistry
+export const REGISTRY_ABI = BookingRegistryArtifact.abi;
+
+export const LISTING_ADDRESS = '0xYourListingImplementationAddressHere'; // Listing implementation
+export const LISTING_ABI = ListingArtifact.abi;
+
+export const FACTORY_ADDRESS = '0xYourListingFactoryAddressHere'; // ListingFactory
+export const FACTORY_ABI = ListingFactoryArtifact.abi;
+
+export const PLATFORM_ADDRESS = '0xYourPlatformAddressHere'; // Platform
+export const PLATFORM_ABI = PlatformArtifact.abi;
+
+export const APP_NAME = 'r3nt';
+export const APP_DOMAIN = 'r3nt.sqmu.net'; // origin used in EIP-712 domain if needed


### PR DESCRIPTION
## Summary
- import the Clean-Slate contract ABIs into the front-end config module
- expose placeholder addresses for the new r3nt-SQMU, BookingRegistry, Listing, ListingFactory, and Platform contracts along with their ABIs
- keep existing network metadata and USDC configuration unchanged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbf2a0c440832abdb0142b71ccd98f