### PR TITLE
Expose build version across Mini App pages

### DIFF
--- a/FIDTest.html
+++ b/FIDTest.html
@@ -22,12 +22,38 @@
   <!-- Recommended for QuickAuth -->
   <link rel="preconnect" href="https://auth.farcaster.xyz" />
   <script src="./js/dev-error-console.js"></script>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; max-width: 460px; margin: 0 auto; padding: 20px; color:#0f172a; background:#ffffff; }
+    nav { margin-bottom:16px; }
+    nav a { margin-right:10px; color:#1f6feb; text-decoration:none; font-weight:600; }
+    .version-badge { display:inline-block; margin-left:8px; padding:2px 6px; border-radius:8px; font-size:.65rem; letter-spacing:.08em; text-transform:uppercase; background:#e2e8f0; color:#475569; }
+    #status { font-size:0.95rem; }
+  </style>
 </head>
 <body>
+  <nav>
+    <a href="./index.html">Home</a>
+    <a href="./tenant.html">Tenant</a>
+    <a href="./landlord.html">Landlord</a>
+    <a href="./admin.html">Admin</a>
+    <span class="version-badge" data-version></span>
+  </nav>
   <div id="status">Loading…</div>
 
   <script type="module">
     import { sdk } from "https://esm.sh/@farcaster/miniapp-sdk";
+    import { APP_VERSION } from './js/config.js';
+
+    const applyVersionBadge = () => {
+      const badge = document.querySelector('[data-version]');
+      if (badge) badge.textContent = `Build ${APP_VERSION}`;
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', applyVersionBadge);
+    } else {
+      applyVersionBadge();
+    }
 
     const status = document.getElementById('status');
 

--- a/admin.html
+++ b/admin.html
@@ -22,6 +22,7 @@
     .muted { color:#666; font-size:0.9rem; }
     nav { margin-bottom:16px; }
     nav a { margin-right:10px; color:#1f6feb; text-decoration:none; font-weight:600; }
+    .version-badge { display:inline-block; margin-left:8px; padding:2px 6px; border-radius:8px; font-size:.65rem; letter-spacing:.08em; text-transform:uppercase; background:#e2e8f0; color:#475569; }
   </style>
   <script src="./js/dev-error-console.js"></script>
 </head>
@@ -31,6 +32,7 @@
     <a href="./tenant.html">Tenant</a>
     <a href="./landlord.html">Landlord</a>
     <a href="./admin.html">Admin</a>
+    <span class="version-badge" data-version></span>
   </nav>
   <h1>r3nt — Deposit Admin</h1>
   <div id="contextBar" class="muted">Starting…</div>

--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
     .btn.secondary{background:#eef2ff;color:#3730a3;border-color:transparent}
     nav{margin-bottom:16px}
     nav a{margin-right:10px;color:var(--primary);font-weight:600;text-decoration:none}
+    .version-badge{display:inline-block;margin-left:8px;padding:2px 6px;border-radius:8px;font-size:.65rem;letter-spacing:.08em;text-transform:uppercase;background:#e2e8f0;color:#475569}
     section{margin-top:28px;padding-top:8px}
     h2{font-size:1.15rem;margin:0 0 8px}
     .grid{display:grid;grid-template-columns:1fr;gap:12px}
@@ -69,9 +70,10 @@
 
     <nav>
       <a href="./index.html">Home</a>
-      <a href="./tenant.html">Tenant</a>
-      <a href="./landlord.html">Landlord</a>
-    </nav>
+    <a href="./tenant.html">Tenant</a>
+    <a href="./landlord.html">Landlord</a>
+    <span class="version-badge" data-version></span>
+  </nav>
 
     <div class="hero">
       <div>
@@ -137,6 +139,19 @@
 
   <script type="module">
     import { sdk } from 'https://esm.sh/@farcaster/miniapp-sdk';
+    import { APP_VERSION } from './js/config.js';
+
+    const applyVersionBadge = () => {
+      const badge = document.querySelector('[data-version]');
+      if (badge) badge.textContent = `Build ${APP_VERSION}`;
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', applyVersionBadge);
+    } else {
+      applyVersionBadge();
+    }
+
     (async () => {
       try { await sdk.actions.ready(); } catch {}
       setTimeout(() => { try { sdk.actions.ready(); } catch {} }, 800);

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,7 +1,7 @@
 import { sdk } from 'https://esm.sh/@farcaster/miniapp-sdk';
 import { createPublicClient, http, encodeFunctionData } from 'https://esm.sh/viem@2.9.32';
 import { arbitrum } from 'https://esm.sh/viem/chains';
-import { CHAIN_ID, RPC_URL, PLATFORM_ADDRESS, PLATFORM_ABI, LISTING_ABI } from './config.js';
+import { CHAIN_ID, RPC_URL, PLATFORM_ADDRESS, PLATFORM_ABI, LISTING_ABI, APP_VERSION } from './config.js';
 
 const CHAIN_ID_HEX = '0x' + CHAIN_ID.toString(16);
 const STATUS_LABELS = ['None', 'Active', 'Completed', 'Cancelled', 'Defaulted'];
@@ -20,6 +20,17 @@ const els = {
 };
 
 const info = (t) => { els.status.textContent = t; };
+
+const applyVersionBadge = () => {
+  const badge = document.querySelector('[data-version]');
+  if (badge) badge.textContent = `Build ${APP_VERSION}`;
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', applyVersionBadge);
+} else {
+  applyVersionBadge();
+}
 
 const pub = createPublicClient({ chain: arbitrum, transport: http(RPC_URL || 'https://arb1.arbitrum.io/rpc') });
 let provider;

--- a/js/config.js
+++ b/js/config.js
@@ -48,3 +48,4 @@ export const PLATFORM_ABI = PlatformArtifact.abi || [];
 
 export const APP_NAME = 'r3nt';
 export const APP_DOMAIN = 'r3nt.sqmu.net'; // origin used in EIP-712 domain if needed
+export const APP_VERSION = '0.1.0';

--- a/landlord.html
+++ b/landlord.html
@@ -39,6 +39,7 @@
     .divider { height:1px; background:#eee; margin:14px 0; }
     nav { margin-bottom:16px; }
     nav a { margin-right:10px; color:#1f6feb; text-decoration:none; font-weight:600; }
+    .version-badge { display:inline-block; margin-left:8px; padding:2px 6px; border-radius:8px; font-size:.65rem; letter-spacing:.08em; text-transform:uppercase; background:#e2e8f0; color:#475569; }
   </style>
   <script src="./js/dev-error-console.js"></script>
 </head>
@@ -48,6 +49,7 @@
     <a href="./tenant.html">Tenant</a>
     <a href="./landlord.html">Landlord</a>
     <a href="./admin.html">Admin</a>
+    <span class="version-badge" data-version></span>
   </nav>
   <h1>r3nt — Create Listing</h1>
 
@@ -132,7 +134,14 @@
     import { createPublicClient, http, encodeFunctionData, parseUnits, getAddress } from 'https://esm.sh/viem@2.9.32';
     import { arbitrum } from 'https://esm.sh/viem/chains';
     import { latLonToGeohash, isHex20or32, toBytes32FromCastHash } from './js/tools.js';
-    import { R3NT_ADDRESS, USDC_ADDRESS, PLATFORM_ADDRESS, RPC_URL, REGISTRY_ADDRESS } from './js/config.js';
+    import {
+      R3NT_ADDRESS,
+      USDC_ADDRESS,
+      PLATFORM_ADDRESS,
+      RPC_URL,
+      REGISTRY_ADDRESS,
+      APP_VERSION,
+    } from './js/config.js';
 
     // -------------------- Config --------------------
     const ARBITRUM_HEX   = '0xa4b1';
@@ -177,6 +186,17 @@
       availResult: document.getElementById('availResult'),
     };
     const info = (t) => els.status.textContent = t;
+
+    const setVersionBadge = () => {
+      const badge = document.querySelector('[data-version]');
+      if (badge) badge.textContent = `Build ${APP_VERSION}`;
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', setVersionBadge);
+    } else {
+      setVersionBadge();
+    }
 
     // helpers
     function utf8BytesLen(str){ return new TextEncoder().encode(str).length; }

--- a/tenant.html
+++ b/tenant.html
@@ -21,6 +21,7 @@
     .row { display:flex; gap:8px; }
     nav { margin-bottom:16px; }
     nav a { margin-right:10px; color:#1f6feb; text-decoration:none; font-weight:600; }
+    .version-badge { display:inline-block; margin-left:8px; padding:2px 6px; border-radius:8px; font-size:.65rem; letter-spacing:.08em; text-transform:uppercase; background:#e2e8f0; color:#475569; }
     select { width:100%; padding:6px; margin:4px 0 8px; }
     a.listing-link { display:inline-block; margin-top:8px; color:#1f6feb; font-weight:600; text-decoration:none; }
     a.listing-link:hover { text-decoration:underline; }
@@ -33,6 +34,7 @@
     <a href="./tenant.html">Tenant</a>
     <a href="./landlord.html">Landlord</a>
     <a href="./admin.html">Admin</a>
+    <span class="version-badge" data-version></span>
   </nav>
   <h1>r3nt View Pass</h1>
   <button id="connect">Connect Wallet</button>
@@ -71,6 +73,7 @@
       PLATFORM_ABI,
       LISTING_ABI,
       USDC_ADDRESS,
+      APP_VERSION,
     } from './js/config.js';
 
     const els = {
@@ -82,6 +85,17 @@
       start: document.getElementById('startDate'),
       end: document.getElementById('endDate'),
     };
+
+    const setVersionBadge = () => {
+      const badge = document.querySelector('[data-version]');
+      if (badge) badge.textContent = `Build ${APP_VERSION}`;
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', setVersionBadge);
+    } else {
+      setVersionBadge();
+    }
 
     const ARBITRUM_HEX = '0xa4b1';           // 42161
     const USDC_SCALAR = 1_000_000n;


### PR DESCRIPTION
## Summary
- export a shared APP_VERSION constant from the public config
- surface a muted version badge in each navigation shell
- hydrate the badge text in every module script so pages show the current build

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc6a629ab8832a940979e661691784