### PR TITLE
Hide landlord identifiers on tenant listing cards

### DIFF
--- a/js/tenant.js
+++ b/js/tenant.js
@@ -291,14 +291,6 @@ function renderListingCard(info){
   title.textContent = `Listing ${short(info.address)}`;
   card.appendChild(title);
 
-  const landlordLine = document.createElement('div');
-  landlordLine.textContent = `Landlord: ${short(info.landlord)}`;
-  card.appendChild(landlordLine);
-
-  const fidLine = document.createElement('div');
-  fidLine.textContent = info.fid > 0n ? `Landlord FID: ${info.fid.toString()}` : 'Landlord FID: —';
-  card.appendChild(fidLine);
-
   const rateLine = document.createElement('div');
   rateLine.textContent = `Base rate: ${formatUsdc(info.baseDailyRate)} USDC / day`;
   card.appendChild(rateLine);


### PR DESCRIPTION
## Summary
- remove the landlord wallet and fid rows from tenant listing cards while preserving booking and Farcaster link logic

## Testing
- python3 -m http.server 8000 (manual smoke test with Playwright client hitting tenant.html)


------
https://chatgpt.com/codex/tasks/task_e_68ccae0b47b4832a984eca6cda276817