### PR TITLE
Enable tenant rent cadence selection

### DIFF
--- a/contracts/Agent.sol
+++ b/contracts/Agent.sol
@@ -22,6 +22,7 @@ interface IListingLike {
     /// @notice Supported rent payment cadences (mirrors `Listing.Period`).
     enum Period {
         NONE,
+        DAY,
         WEEK,
         MONTH
     }

--- a/js/abi/Listing.json
+++ b/js/abi/Listing.json
@@ -26,6 +26,11 @@
           "internalType": "uint64",
           "name": "end",
           "type": "uint64"
+        },
+        {
+          "internalType": "enum Listing.Period",
+          "name": "period",
+          "type": "uint8"
         }
       ],
       "name": "book",

--- a/tenant.html
+++ b/tenant.html
@@ -50,6 +50,14 @@
       <input type="date" id="endDate">
     </label>
   </div>
+  <label>Rent payment cadence
+    <select id="paymentPeriod">
+      <option value="">Select cadence…</option>
+      <option value="day">Daily</option>
+      <option value="week">Weekly</option>
+      <option value="month">Monthly</option>
+    </select>
+  </label>
   <h2>Listings</h2>
   <div id="listings"></div>
   <script type="module" src="./js/tenant.js"></script>


### PR DESCRIPTION
## Summary
- extend the listing contract so tenants select a daily, weekly or monthly rent cadence and enforce per-period payment caps when paying rent
- keep tokenisation flows and the agent interface aligned with the expanded rent period enum
- update the tenant mini app UI and ABI to capture the chosen cadence and surface the expected installment amount

## Testing
- not run (no automated test suite provided)


------
https://chatgpt.com/codex/tasks/task_e_68cde831a9c8832a9c90543cc86e177f