### PR TITLE
Fix MetaMask SDK namespace access

### DIFF
--- a/js/platform-only-metamask-wallet.js
+++ b/js/platform-only-metamask-wallet.js
@@ -1,7 +1,12 @@
 // wallet.js - shared wallet helpers for SQMU widgets
 // This module relies on ethers.js and MetaMask SDK loaded via CDN.
 
-const MMSDK = new MetaMaskSDK.MetaMaskSDK({
+const metaMaskNamespace = window.MetaMaskSDK;
+if (!metaMaskNamespace || !metaMaskNamespace.MetaMaskSDK) {
+  throw new Error('MetaMask SDK not found. Ensure the UMD bundle is loaded before wallet helpers.');
+}
+
+const MMSDK = new metaMaskNamespace.MetaMaskSDK({
   dappMetadata: { name: 'SQMU Wallet', url: window.location.href },
   infuraAPIKey: '822e08935dea4fb48f668ff353ac863a',
 });


### PR DESCRIPTION
## Summary
- look up the MetaMask SDK through the window namespace before creating the SDK instance
- throw a clear error when the SDK bundle is missing so the platform wallet helper fails fast

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ce9164ecfc832a8c27defbcec9327e