### PR TITLE
Fix front-end init errors and hide platform nav

### DIFF
--- a/FIDTest.html
+++ b/FIDTest.html
@@ -38,7 +38,6 @@
     <a href="./investor.html">Investor</a>
     <a href="./agent.html">Agent</a>
     <a href="./admin.html">Admin</a>
-    <a href="./platform.html">Platform</a>
     <span class="version-badge" data-version></span>
   </nav>
   <div id="status">Loading…</div>

--- a/admin.html
+++ b/admin.html
@@ -41,7 +41,6 @@
     <a href="./investor.html">Investor</a>
     <a href="./agent.html">Agent</a>
     <a href="./admin.html">Admin</a>
-    <a href="./platform.html">Platform</a>
     <span class="version-badge" data-version></span>
   </nav>
   <div id="notificationTray" class="notification-tray"></div>

--- a/agent.html
+++ b/agent.html
@@ -63,7 +63,6 @@
     <a href="./investor.html">Investor</a>
     <a href="./agent.html">Agent</a>
     <a href="./admin.html">Admin</a>
-    <a href="./platform.html">Platform</a>
     <span class="version-badge" data-version></span>
   </nav>
   <div id="notificationTray" class="notification-tray"></div>

--- a/index.html
+++ b/index.html
@@ -87,7 +87,6 @@
       <a href="./investor.html">Investor</a>
       <a href="./agent.html">Agent</a>
       <a href="./admin.html">Admin</a>
-      <a href="./platform.html">Platform</a>
       <span class="version-badge" data-version></span>
     </nav>
 

--- a/investor.html
+++ b/investor.html
@@ -58,7 +58,6 @@
     <a href="./investor.html">Investor</a>
     <a href="./agent.html">Agent</a>
     <a href="./admin.html">Admin</a>
-    <a href="./platform.html">Platform</a>
     <span class="version-badge" data-version></span>
   </nav>
   <div id="notificationTray" class="notification-tray"></div>

--- a/js/landlord.js
+++ b/js/landlord.js
@@ -52,6 +52,30 @@ const info = (t) => (els.status.textContent = t);
 
 mountNotificationCenter(document.getElementById('notificationTray'), { role: 'landlord' });
 
+const checklistItems = {
+  basics: document.querySelector('[data-check="basics"]'),
+  location: document.querySelector('[data-check="location"]'),
+  pricing: document.querySelector('[data-check="pricing"]'),
+  policies: document.querySelector('[data-check="policies"]'),
+};
+
+const checkpointLabels = {
+  basics: 'Basics',
+  location: 'Location & size',
+  pricing: 'Pricing',
+  policies: 'Policies',
+};
+
+const checkpointState = {
+  basics: false,
+  location: false,
+  pricing: false,
+  policies: false,
+};
+
+let lastAllComplete = false;
+let walletConnected = false;
+
 const onboardingFields = [
   'title',
   'shortDesc',
@@ -250,29 +274,6 @@ function normalizeCastHash(h) {
   return toBytes32FromCastHash(hex);
 }
 
-const checklistItems = {
-  basics: document.querySelector('[data-check="basics"]'),
-  location: document.querySelector('[data-check="location"]'),
-  pricing: document.querySelector('[data-check="pricing"]'),
-  policies: document.querySelector('[data-check="policies"]'),
-};
-
-const checkpointLabels = {
-  basics: 'Basics',
-  location: 'Location & size',
-  pricing: 'Pricing',
-  policies: 'Policies',
-};
-
-const checkpointState = {
-  basics: false,
-  location: false,
-  pricing: false,
-  policies: false,
-};
-
-let lastAllComplete = false;
-let walletConnected = false;
 function disableWhile(el, fn) {
   return (async () => {
     el.disabled = true;

--- a/js/tenant.js
+++ b/js/tenant.js
@@ -39,6 +39,16 @@ const els = {
   },
 };
 
+let selectedListing = null;
+let selectedCard = null;
+let selectedListingTitle = '';
+let pub;
+let viewPassPrice;
+let viewPassDuration;
+let configLoading;
+let viewPassRequired = false;
+let hasActiveViewPass = false;
+
 mountNotificationCenter(document.getElementById('notificationTray'), { role: 'tenant' });
 
 if (els.period && !els.period.value) {
@@ -82,10 +92,6 @@ const PERIOD_OPTIONS = {
 const supportsViewPassPurchase = PLATFORM_ABI.some(
   (item) => item?.type === 'function' && item?.name === 'buyViewPass'
 );
-
-let selectedListing = null;
-let selectedCard = null;
-let selectedListingTitle = '';
 
 function formatUsdc(amount) {
   const value = typeof amount === 'bigint' ? amount : BigInt(amount || 0);
@@ -360,13 +366,6 @@ function setSelectedListing(info, card) {
     notify({ message: `Planning stay at ${selectedListingTitle}`, variant: 'info', role: 'tenant', timeout: 4200 });
   }
 }
-
-let pub;
-let viewPassPrice;
-let viewPassDuration;
-let configLoading;
-let viewPassRequired = false;
-let hasActiveViewPass = false;
 
 function updateBuyLabel() {
   const parts = [];

--- a/landlord.html
+++ b/landlord.html
@@ -85,7 +85,6 @@
     <a href="./investor.html">Investor</a>
     <a href="./agent.html">Agent</a>
     <a href="./admin.html">Admin</a>
-    <a href="./platform.html">Platform</a>
     <span class="version-badge" data-version></span>
   </nav>
   <div id="notificationTray" class="notification-tray"></div>

--- a/platform.html
+++ b/platform.html
@@ -167,7 +167,6 @@
     <a href="./investor.html">Investor</a>
     <a href="./agent.html">Agent</a>
     <a href="./admin.html">Admin</a>
-    <a href="./platform.html">Platform</a>
     <span class="version-badge" data-version></span>
   </nav>
   <div id="notificationTray" class="notification-tray"></div>

--- a/tenant.html
+++ b/tenant.html
@@ -67,7 +67,6 @@
     <a href="./investor.html">Investor</a>
     <a href="./agent.html">Agent</a>
     <a href="./admin.html">Admin</a>
-    <a href="./platform.html">Platform</a>
     <span class="version-badge" data-version></span>
   </nav>
   <div id="notificationTray" class="notification-tray"></div>


### PR DESCRIPTION
## Summary
- ensure tenant summary state variables are defined before running the initial update
- initialize landlord onboarding checklist handles ahead of the first progress calculation
- remove the Platform link from all public navigation bars to keep the owner console hidden

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceeaa75798832aba56aa50911f29c0