### PR TITLE
Add configurable dev console toggle

### DIFF
--- a/FIDTest.html
+++ b/FIDTest.html
@@ -21,6 +21,7 @@
 
   <!-- Recommended for QuickAuth -->
   <link rel="preconnect" href="https://auth.farcaster.xyz" />
+  <script src="./js/dev-settings.js"></script>
   <script src="./js/dev-error-console.js"></script>
   <style>
     body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; max-width: 460px; margin: 0 auto; padding: 20px; color:#0f172a; background:#ffffff; }

--- a/admin.html
+++ b/admin.html
@@ -35,6 +35,7 @@
     .notification-message { margin-right:12px; font-size:.9rem; }
     .notification-close { background:transparent; border:0; color:inherit; font-size:1.1rem; cursor:pointer; padding:0 4px; }
   </style>
+  <script src="./js/dev-settings.js"></script>
   <script src="./js/dev-error-console.js"></script>
 </head>
 <body>

--- a/agent.html
+++ b/agent.html
@@ -57,6 +57,7 @@
       .actions { flex-direction:column; }
     }
   </style>
+  <script src="./js/dev-settings.js"></script>
   <script src="./js/dev-error-console.js"></script>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
     }
     footer{margin-top:28px;padding-top:12px;border-top:1px solid var(--stroke);font-size:.9rem;color:var(--muted)}
   </style>
+  <script src="./js/dev-settings.js"></script>
   <script src="./js/dev-error-console.js"></script>
 </head>
 <body>

--- a/investor.html
+++ b/investor.html
@@ -52,6 +52,7 @@
       button { width:100%; }
     }
   </style>
+  <script src="./js/dev-settings.js"></script>
   <script src="./js/dev-error-console.js"></script>
 </head>
 <body>

--- a/js/dev-settings.js
+++ b/js/dev-settings.js
@@ -1,0 +1,20 @@
+(function () {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.__R3NT_DEV_SETTINGS__ = {
+    /**
+     * Set to `true` to force the developer console on for every page.
+     * Set to `false` to force the console off everywhere.
+     * Set to `null` (or remove this property) to use the per-browser toggle
+     * managed from the Platform admin view.
+     */
+    devConsoleOverride: true,
+    /**
+     * When `devConsoleOverride` is `null`, this value controls the default state
+     * if there is no preference stored in localStorage.
+     */
+    devConsoleDefault: false,
+  };
+})();

--- a/landlord.html
+++ b/landlord.html
@@ -79,6 +79,7 @@
     .guided-section h3 { margin:0 0 6px; font-size:1.05rem; }
     .guided-section p.section-subtext { margin:0 0 12px; font-size:.85rem; color:#64748b; }
   </style>
+  <script src="./js/dev-settings.js"></script>
   <script src="./js/dev-error-console.js"></script>
 </head>
 <body>

--- a/platform.html
+++ b/platform.html
@@ -155,6 +155,7 @@
       .button-row { flex-direction: column; align-items: stretch; }
     }
   </style>
+  <script src="./js/dev-settings.js"></script>
   <script src="./js/dev-error-console.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
   <script src="https://c0f4f41c-2f55-4863-921b-sdk-docs.github.io/cdn/metamask-sdk.js"></script>

--- a/tenant.html
+++ b/tenant.html
@@ -61,6 +61,7 @@
       button { width:auto; }
     }
   </style>
+  <script src="./js/dev-settings.js"></script>
   <script src="./js/dev-error-console.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add a shared dev settings script that exposes a manual override for the in-app console
- update the dev error console to respect the new override/default values and persist disabled state explicitly
- load the settings script on every page so the dev console can be forced on across the whole app

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf4e0a1a90832abdc1ca654e13f769