### PR TITLE
Fix back navigation fallback

### DIFF
--- a/js/back-navigation.js
+++ b/js/back-navigation.js
@@ -48,7 +48,11 @@ export function createBackController({ sdk = importedSdk, button, isDeep } = {})
   ensureBaseHistoryState();
 
   const update = () => {
-    const active = stack.length > 0 || Boolean(externalDepthCheck?.());
+    const internalActive = stack.length > 0 || Boolean(externalDepthCheck?.());
+    const hostNavigationAvailable = hostSupportsBack && Boolean(sdk?.back);
+    const fallbackActive = !hostNavigationAvailable && window.history.length > 1;
+    const active = internalActive || fallbackActive;
+
     if (button) {
       if (active) {
         button.removeAttribute('hidden');
@@ -56,17 +60,19 @@ export function createBackController({ sdk = importedSdk, button, isDeep } = {})
         button.setAttribute('hidden', '');
       }
     }
-    if (hostSupportsBack && sdk?.back) {
+
+    if (hostNavigationAvailable) {
       try {
-        if (active) {
-          sdk.back.show?.();
-        } else {
+        if (internalActive) {
           sdk.back.hide?.();
+        } else {
+          sdk.back.show?.();
         }
       } catch (err) {
         console.warn('Failed toggling host back affordance', err);
       }
     }
+
     return active;
   };
 


### PR DESCRIPTION
## Summary
- ensure the back controller does not hide the host affordance when the internal stack is empty
- surface the inline back button whenever the host cannot provide navigation and the browser history has depth

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cf51ccde64832aa9beabd6154b46da