### PR TITLE
Remove cadence wording from booking flow UI

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -114,7 +114,7 @@
       <label>Fundraising fee (bps)
         <input id="fundraisingFee" inputmode="numeric" autocomplete="off" />
       </label>
-      <label>Rent cadence
+      <label>Rent payment timing
         <select id="fundraisingPeriod">
           <option value="1">Daily</option>
           <option value="2">Weekly</option>

--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
           <p>Track tokenised bookings, SQMU-R positions and live rent accruals.</p>
           <ul>
             <li>Connect your wallet to surface bookings where you hold SQMU-R.</li>
-            <li>Review fundraising caps, sold supply and rent distribution cadence per booking.</li>
+            <li>Review fundraising caps, sold supply and rent distribution timing per booking.</li>
             <li>Claim accumulated rent in a single click directly from the dashboard.</li>
           </ul>
           <div class="role-actions">

--- a/js/agent.js
+++ b/js/agent.js
@@ -699,7 +699,7 @@ if (els.fundraisingForm) {
       feeBps = parseBpsInput(els.fundraisingFee?.value, 'Fundraising fee');
       periodValue = Number((els.fundraisingPeriod?.value ?? '').trim() || '3');
       if (!Number.isInteger(periodValue) || periodValue <= 0) {
-        throw new Error('Select a rent cadence.');
+        throw new Error('Select how often rent is paid.');
       }
     } catch (err) {
       console.error('Fundraising input error', err);

--- a/js/tenant.js
+++ b/js/tenant.js
@@ -252,7 +252,7 @@ function updateSummary() {
   setText(summary.nights, '—');
   setText(summary.deposit, listing ? (depositAmount > 0n ? `${formatUsdc(depositAmount)} USDC` : 'No deposit') : '—');
   setText(summary.rent, listing ? '0 USDC' : '—');
-  setText(summary.installment, listing ? 'Choose cadence' : '—');
+  setText(summary.installment, listing ? 'Select how often to pay rent' : '—');
   setText(summary.total, listing ? (depositAmount > 0n ? `${formatUsdc(depositAmount)} USDC` : '0 USDC') : '—');
   setText(summary.notice, listing ? 'Select stay dates to continue.' : 'Pick a property to enable booking.');
 
@@ -292,7 +292,7 @@ function updateSummary() {
   const periodKey = els.period?.value || '';
   const selectedPeriod = PERIOD_OPTIONS[periodKey];
   if (!selectedPeriod) {
-    setText(summary.notice, 'Pick a rent payment cadence.');
+    setText(summary.notice, "Pick how often you'll pay rent.");
     return;
   }
 
@@ -314,7 +314,7 @@ function updateSummary() {
     summary.installment,
     installmentCap > 0n
       ? `${selectedPeriod.label} up to ${formatUsdc(installmentCap)} USDC`
-      : `${selectedPeriod.label} cadence`
+      : `${selectedPeriod.label} payments`
   );
 
   setText(summary.total, depositAmount > 0n ? `${formatUsdc(depositAmount)} USDC` : '0 USDC');
@@ -772,7 +772,7 @@ async function bookListing(listing = selectedListing){
     if (endTs <= startTs) throw new Error('End date must be after start.');
     const periodKey = els.period ? els.period.value : '';
     const selectedPeriod = PERIOD_OPTIONS[periodKey];
-    if (!selectedPeriod) throw new Error('Select a rent payment cadence.');
+    if (!selectedPeriod) throw new Error("Select how often you'll pay rent.");
     const nowTs = BigInt(Math.floor(Date.now() / 1000));
     if (listing.minBookingNotice > 0n && startTs < nowTs + listing.minBookingNotice) {
       throw new Error(`Start must respect the ${formatDuration(listing.minBookingNotice)} minimum notice.`);

--- a/landlord.html
+++ b/landlord.html
@@ -128,7 +128,7 @@
         <span class="status-dot"></span>
         <div>
           <strong>Pricing</strong>
-          <small>Deposit plus at least one rent cadence.</small>
+          <small>Deposit plus at least one rent installment.</small>
         </div>
       </li>
       <li data-check="policies">

--- a/tenant.html
+++ b/tenant.html
@@ -86,7 +86,7 @@
   <div id="status">Loading…</div>
   <div class="planner-card">
     <h2>Plan your stay</h2>
-    <p>Choose dates and a payment cadence to preview totals before booking.</p>
+    <p>Choose dates and how often you'd like to pay to preview totals before booking.</p>
     <div class="planner-grid">
       <div class="planner-inputs">
         <label>Check-in
@@ -95,9 +95,9 @@
         <label>Check-out
           <input type="date" id="endDate">
         </label>
-        <label>Rent payment cadence
+        <label>How often you'll pay rent
           <select id="paymentPeriod">
-            <option value="">Select cadence…</option>
+            <option value="">Select how often…</option>
             <option value="day">Daily</option>
             <option value="week">Weekly</option>
             <option value="month">Monthly</option>


### PR DESCRIPTION
## Summary
- replace “cadence” phrasing in the tenant planner with context-driven language
- update landlord, investor, and agent screens to describe rent timing instead of cadence
- align booking validation and status messages with the new wording

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf560c5cf8832a918b22b87cf7c41b