### PR TITLE
Add consistent footer across HTML pages

### DIFF
--- a/FIDTest.html
+++ b/FIDTest.html
@@ -29,6 +29,7 @@
     nav a { margin-right:10px; color:#1f6feb; text-decoration:none; font-weight:600; }
     .version-badge { display:inline-block; margin-left:8px; padding:2px 6px; border-radius:8px; font-size:.65rem; letter-spacing:.08em; text-transform:uppercase; background:#e2e8f0; color:#475569; }
     #status { font-size:0.95rem; }
+    footer { margin-top:32px; padding-top:12px; border-top:1px solid #e2e8f0; font-size:.9rem; color:#475569; text-align:center; }
   </style>
 </head>
 <body>
@@ -42,6 +43,10 @@
     <span class="version-badge" data-version></span>
   </nav>
   <div id="status">Loading…</div>
+
+  <footer>
+    r3nt by SQMU. USDC. Arbitrum.
+  </footer>
 
   <script type="module">
     import { sdk } from "https://esm.sh/@farcaster/miniapp-sdk";

--- a/admin.html
+++ b/admin.html
@@ -34,6 +34,7 @@
     .notification.notification-warning { border-color:#fef08a; background:#fffbeb; color:#92400e; }
     .notification-message { margin-right:12px; font-size:.9rem; }
     .notification-close { background:transparent; border:0; color:inherit; font-size:1.1rem; cursor:pointer; padding:0 4px; }
+    footer { margin-top:32px; padding-top:12px; border-top:1px solid var(--stroke, #e2e8f0); font-size:.9rem; color:var(--muted, #475569); text-align:center; }
   </style>
   <script src="./js/dev-settings.js"></script>
   <script src="./js/dev-error-console.js"></script>
@@ -70,6 +71,9 @@
   <button id="confirm" disabled>Confirm Deposit Release</button>
   <div id="bookingInfo" class="muted"></div>
   <div id="status"></div>
+  <footer>
+    r3nt by SQMU. USDC. Arbitrum.
+  </footer>
   <script type="module" src="./js/admin.js"></script>
 </body>
 </html>

--- a/agent.html
+++ b/agent.html
@@ -52,6 +52,7 @@
     .form-grid button { justify-self:start; }
     .empty-state { color:#64748b; font-size:.9rem; }
     .inline-group { display:flex; flex-wrap:wrap; gap:10px; }
+    footer { margin-top:32px; padding-top:12px; border-top:1px solid var(--stroke); font-size:.9rem; color:var(--muted); text-align:center; }
     @media (max-width:640px) {
       button { width:100%; }
       .actions { flex-direction:column; }
@@ -192,6 +193,10 @@
       <button type="submit">Record sublet rent</button>
     </form>
   </section>
+
+  <footer>
+    r3nt by SQMU. USDC. Arbitrum.
+  </footer>
 
   <script type="module" src="./js/agent.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
       .hero{grid-template-columns:1.3fr .7fr}
       .grid{grid-template-columns:1fr 1fr}
     }
-    footer{margin-top:28px;padding-top:12px;border-top:1px solid var(--stroke);font-size:.9rem;color:var(--muted)}
+    footer{margin-top:32px;padding-top:12px;border-top:1px solid var(--stroke, #e2e8f0);font-size:.9rem;color:var(--muted, #475569);text-align:center}
   </style>
   <script src="./js/dev-settings.js"></script>
   <script src="./js/dev-error-console.js"></script>
@@ -222,7 +222,7 @@
 </section>
 
     <footer>
-      r3nt is a product of SQMU. USDC is the settlement method. Network is Arbitrum.
+      r3nt by SQMU. USDC. Arbitrum.
     </footer>
   </div>
 

--- a/investor.html
+++ b/investor.html
@@ -47,6 +47,7 @@
     .empty-state { color:#64748b; font-size:.9rem; }
     .muted { color:#64748b; }
     .highlight { color:var(--success); font-weight:600; }
+    footer { margin-top:32px; padding-top:12px; border-top:1px solid var(--stroke); font-size:.9rem; color:var(--muted); text-align:center; }
     @media (max-width:560px){
       .metric-row { flex-direction:column; }
       button { width:100%; }
@@ -99,6 +100,10 @@
       <div class="empty-state">No claimable rent yet.</div>
     </div>
   </section>
+
+  <footer>
+    r3nt by SQMU. USDC. Arbitrum.
+  </footer>
 
   <script type="module" src="./js/investor.js"></script>
 </body>

--- a/landlord.html
+++ b/landlord.html
@@ -78,6 +78,7 @@
     .guided-section { border:1px solid #e2e8f0; border-radius:16px; background:#fff; padding:16px; margin-top:18px; }
     .guided-section h3 { margin:0 0 6px; font-size:1.05rem; }
     .guided-section p.section-subtext { margin:0 0 12px; font-size:.85rem; color:#64748b; }
+    footer { margin-top:32px; padding-top:12px; border-top:1px solid var(--stroke, #e2e8f0); font-size:.9rem; color:var(--muted, #475569); text-align:center; }
   </style>
   <script src="./js/dev-settings.js"></script>
   <script src="./js/dev-error-console.js"></script>
@@ -220,6 +221,10 @@
   <h2>Your Listings</h2>
   <div class="muted"><small>Check availability for each listing below.</small></div>
   <div id="landlordListings" class="muted">Connect wallet to load your listings.</div>
+
+  <footer>
+    r3nt by SQMU. USDC. Arbitrum.
+  </footer>
 
   <script type="module" src="./js/landlord.js"></script>
 </body>

--- a/platform.html
+++ b/platform.html
@@ -124,6 +124,14 @@
       font-size: 0.9rem;
       margin: 8px 0 0;
     }
+    footer {
+      margin-top: 32px;
+      padding-top: 12px;
+      border-top: 1px solid var(--stroke, #e2e8f0);
+      font-size: 0.9rem;
+      color: var(--muted);
+      text-align: center;
+    }
     #snapshotOutput {
       font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Consolas, 'Liberation Mono', monospace;
       font-size: 0.88rem;
@@ -365,6 +373,10 @@
     <p class="muted">Status updates for submitted transactions appear here.</p>
     <div id="actionStatus" class="muted">No activity yet.</div>
   </section>
+
+  <footer>
+    r3nt by SQMU. USDC. Arbitrum.
+  </footer>
 
   <script type="module" src="./js/platform.js"></script>
 </body>

--- a/tenant.html
+++ b/tenant.html
@@ -56,6 +56,7 @@
     .info-dot { display:inline-flex; align-items:center; justify-content:center; width:18px; height:18px; border-radius:50%; background:#e0f2fe; color:#0369a1; font-size:.75rem; margin-left:6px; }
     .card.selected { border-color:#3b82f6; box-shadow:0 8px 20px rgba(59,130,246,0.18); }
     .listing-actions { margin-top:12px; display:flex; flex-direction:column; gap:8px; }
+    footer { margin-top:32px; padding-top:12px; border-top:1px solid var(--stroke, #e2e8f0); font-size:.9rem; color:var(--muted, #475569); text-align:center; }
     @media (min-width: 640px) {
       .planner-grid { grid-template-columns: 1fr 1fr; }
       button { width:auto; }
@@ -123,6 +124,9 @@
   </div>
   <h2>Listings</h2>
   <div id="listings"></div>
+  <footer>
+    r3nt by SQMU. USDC. Arbitrum.
+  </footer>
   <script type="module" src="./js/tenant.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add consistent footer styling across every HTML entry point
- display the shared “r3nt by SQMU. USDC. Arbitrum.” footer text on each page

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf5738c128832aa1009a58aaa3748c