### PR TITLE
Add shared header and enlarge brand typography

### DIFF
--- a/FIDTest.html
+++ b/FIDTest.html
@@ -25,6 +25,10 @@
   <script src="./js/dev-error-console.js"></script>
   <style>
     body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; max-width: 460px; margin: 0 auto; padding: 20px; color:#0f172a; background:#ffffff; }
+    header { margin-bottom: 16px; }
+    .brand { font-weight: 800; letter-spacing: .3px; font-size: 1.3rem; }
+    .beta-note { font-size: .9rem; margin: -12px 0 16px; }
+    .muted { color:#475569; }
     nav { margin-bottom:16px; }
     nav a { margin-right:10px; color:#1f6feb; text-decoration:none; font-weight:600; }
     .version-badge { display:inline-block; margin-left:8px; padding:2px 6px; border-radius:8px; font-size:.65rem; letter-spacing:.08em; text-transform:uppercase; background:#e2e8f0; color:#475569; }
@@ -33,6 +37,12 @@
   </style>
 </head>
 <body>
+  <header>
+    <div class="brand">r3nt by SQMU</div>
+  </header>
+
+  <div class="muted beta-note">early beta.</div>
+
   <nav>
     <a href="./index.html">Home</a>
     <a href="./tenant.html">Tenant</a>

--- a/admin.html
+++ b/admin.html
@@ -7,6 +7,9 @@
   <style>
     :root { --fg:#0f172a; --bg:#ffffff; }
     body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; max-width: 460px; margin: 0 auto; padding: 16px 16px 40px; background: var(--bg); color: var(--fg); }
+    header { margin-bottom: 16px; }
+    .brand { font-weight: 800; letter-spacing: .3px; font-size: 1.3rem; }
+    .beta-note { font-size: .9rem; margin: -12px 0 16px; }
     h1 { font-size: 1.25rem; margin: 8px 0 12px; }
     .row { display: flex; gap: 10px; }
     label { display: block; font-size: .9rem; margin: 10px 0 6px; }
@@ -40,6 +43,12 @@
   <script src="./js/dev-error-console.js"></script>
 </head>
 <body>
+  <header>
+    <div class="brand">r3nt by SQMU</div>
+  </header>
+
+  <div class="muted beta-note">early beta.</div>
+
   <nav>
     <button type="button" class="back-button" data-back-button hidden aria-label="Go back">
       <span aria-hidden="true">←</span>

--- a/agent.html
+++ b/agent.html
@@ -10,6 +10,9 @@
       --accent:#1f6feb; --accent-ink:#ffffff; --success:#10b981; --danger:#dc2626;
     }
     body { font-family: system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif; max-width: 760px; margin:0 auto; padding:24px 16px 72px; background:var(--bg); color:var(--fg); }
+    header { margin-bottom: 16px; }
+    .brand { font-weight: 800; letter-spacing: .3px; font-size: 1.3rem; }
+    .beta-note { font-size: .9rem; margin: -12px 0 16px; }
     nav { margin-bottom:18px; display:flex; align-items:center; flex-wrap:wrap; gap:10px; }
     nav a { color:var(--accent); text-decoration:none; font-weight:600; }
     .back-button { appearance:none; border:1px solid var(--stroke); background:#fff; color:var(--fg); padding:8px 12px; border-radius:999px; font-weight:600; display:inline-flex; align-items:center; gap:6px; cursor:pointer; }
@@ -62,6 +65,12 @@
   <script src="./js/dev-error-console.js"></script>
 </head>
 <body>
+  <header>
+    <div class="brand">r3nt by SQMU</div>
+  </header>
+
+  <div class="muted beta-note">early beta.</div>
+
   <nav>
     <button type="button" class="back-button" data-back-button hidden aria-label="Go back">
       <span aria-hidden="true">←</span>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     body{margin:0;background:var(--bg);color:var(--fg);font:16px/1.6 system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
     .wrap{max-width:920px;margin:0 auto;padding:32px 16px}
     header{display:flex;align-items:center;justify-content:space-between;margin-bottom:16px}
-    .brand{font-weight:800;letter-spacing:.3px}
+    .brand{font-weight:800;letter-spacing:.3px;font-size:1.3rem}
     .pill{display:inline-block;padding:2px 10px;border-radius:999px;background:#e6f4ff;color:#075985;font-weight:600;font-size:.8rem}
     .beta-note{font-size:.9rem;margin:-12px 0 16px}
     .hero{display:grid;grid-template-columns:1fr;gap:18px;padding:22px;border:1px solid var(--stroke);border-radius:16px;background:var(--card)}

--- a/investor.html
+++ b/investor.html
@@ -10,6 +10,9 @@
       --accent:#1f6feb; --accent-ink:#ffffff; --success:#10b981; --danger:#dc2626;
     }
     body { font-family: system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif; max-width: 720px; margin:0 auto; padding:24px 16px 64px; background:var(--bg); color:var(--fg); }
+    header { margin-bottom: 16px; }
+    .brand { font-weight: 800; letter-spacing: .3px; font-size: 1.3rem; }
+    .beta-note { font-size: .9rem; margin: -12px 0 16px; }
     nav { margin-bottom:18px; display:flex; align-items:center; flex-wrap:wrap; gap:10px; }
     nav a { color:var(--accent); text-decoration:none; font-weight:600; }
     .back-button { appearance:none; border:1px solid var(--stroke); background:#fff; color:var(--fg); padding:8px 12px; border-radius:999px; font-weight:600; display:inline-flex; align-items:center; gap:6px; cursor:pointer; }
@@ -57,6 +60,12 @@
   <script src="./js/dev-error-console.js"></script>
 </head>
 <body>
+  <header>
+    <div class="brand">r3nt by SQMU</div>
+  </header>
+
+  <div class="muted beta-note">early beta.</div>
+
   <nav>
     <button type="button" class="back-button" data-back-button hidden aria-label="Go back">
       <span aria-hidden="true">←</span>

--- a/landlord.html
+++ b/landlord.html
@@ -24,6 +24,9 @@
   <style>
     :root { --fg:#0f172a; --bg:#ffffff; }
     body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; max-width: 460px; margin: 0 auto; padding: 16px 16px 40px; background: var(--bg); color: var(--fg); }
+    header { margin-bottom: 16px; }
+    .brand { font-weight: 800; letter-spacing: .3px; font-size: 1.3rem; }
+    .beta-note { font-size: .9rem; margin: -12px 0 16px; }
     h1 { font-size: 1.25rem; margin: 8px 0 12px; }
     .row { display: flex; gap: 10px; flex-wrap: wrap; }
     label { display: block; font-size: .9rem; margin: 10px 0 6px; }
@@ -107,6 +110,12 @@
   <script src="./js/dev-error-console.js"></script>
 </head>
 <body>
+  <header>
+    <div class="brand">r3nt by SQMU</div>
+  </header>
+
+  <div class="muted beta-note">early beta.</div>
+
   <nav>
     <button type="button" class="back-button" data-back-button hidden aria-label="Go back">
       <span aria-hidden="true">←</span>

--- a/platform.html
+++ b/platform.html
@@ -24,6 +24,9 @@
       padding: 16px 16px 48px;
       max-width: 760px;
     }
+    header { margin-bottom: 16px; }
+    .brand { font-weight: 800; letter-spacing: .3px; font-size: 1.3rem; }
+    .beta-note { font-size: .9rem; margin: -12px 0 16px; }
     .version-badge { display:inline-block; margin-left:8px; padding:2px 6px; border-radius:8px; font-size:.65rem; letter-spacing:.08em; text-transform:uppercase; background:#e2e8f0; color:#475569; }
     nav { margin-bottom:18px; }
     nav a { margin-right:10px; color:var(--accent); font-weight:600; text-decoration:none; }
@@ -169,6 +172,12 @@
   <script src="https://c0f4f41c-2f55-4863-921b-sdk-docs.github.io/cdn/metamask-sdk.js"></script>
 </head>
 <body>
+  <header>
+    <div class="brand">r3nt by SQMU</div>
+  </header>
+
+  <div class="muted beta-note">early beta.</div>
+
   <nav>
     <a href="./index.html">Home</a>
     <a href="./tenant.html">Tenant</a>

--- a/tenant.html
+++ b/tenant.html
@@ -10,6 +10,10 @@
   <style>
     :root { --fg:#0f172a; --bg:#ffffff; }
     body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; max-width: 460px; margin: 0 auto; padding: 20px; background: var(--bg); color: var(--fg); }
+    header { margin-bottom: 16px; }
+    .brand { font-weight: 800; letter-spacing: .3px; font-size: 1.3rem; }
+    .beta-note { font-size: .9rem; margin: -12px 0 16px; }
+    .muted { color:#475569; }
     button { width: 100%; padding: 12px 16px; border: 0; border-radius: 10px; font-weight: 700; cursor: pointer; }
     button:disabled { opacity: .6; cursor: not-allowed; }
     #connect { background: #1f6feb; color: #fff; }
@@ -78,6 +82,12 @@
   <script src="./js/dev-error-console.js"></script>
 </head>
 <body>
+  <header>
+    <div class="brand">r3nt by SQMU</div>
+  </header>
+
+  <div class="muted beta-note">early beta.</div>
+
   <nav>
     <button type="button" class="back-button" data-back-button hidden aria-label="Go back">
       <span aria-hidden="true">←</span>


### PR DESCRIPTION
## Summary
- add the r3nt by SQMU header and beta note banner to every console page for consistent branding
- bump the brand typography size across pages to keep the masthead prominent

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68cf71009100832a85d606721654c02a