### PR TITLE
Update tenant map link to Google Maps search

### DIFF
--- a/js/tenant.js
+++ b/js/tenant.js
@@ -705,7 +705,7 @@ function renderListingCard(info){
       geoLine.appendChild(copyBtn);
 
       const mapLink = document.createElement('a');
-      mapLink.href = `geo:${preciseCoords}`;
+      mapLink.href = `https://www.google.com/maps/search/?api=1&query=${preciseCoords}`;
       mapLink.target = '_blank';
       mapLink.rel = 'noopener';
       mapLink.className = 'geo-map-link';


### PR DESCRIPTION
## Summary
- update the tenant listing map link to open Google Maps search with the listing coordinates

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf81f15984832ab3928007ffedab47