### PR TITLE
Remove geohash region labels from landlord and tenant flows

### DIFF
--- a/js/landlord.js
+++ b/js/landlord.js
@@ -3,7 +3,6 @@ import { createPublicClient, http, encodeFunctionData, parseUnits, getAddress, e
 import { arbitrum } from 'https://esm.sh/viem/chains';
 import { assertLatLon, geohashToLatLon, latLonToGeohash, isHex20or32, toBytes32FromCastHash } from './tools.js';
 import { notify, mountNotificationCenter } from './notifications.js';
-import { lookupRegionForGeohash } from './georegions.js';
 import {
   PLATFORM_ADDRESS,
   PLATFORM_ABI,
@@ -40,7 +39,6 @@ const els = {
   lat: document.getElementById('lat'),
   lon: document.getElementById('lon'),
   geohash: document.getElementById('geohash'),
-  geohashRegion: document.getElementById('geohashRegion'),
   useLocation: document.getElementById('useLocation'),
   title: document.getElementById('title'),
   shortDesc: document.getElementById('shortDesc'),
@@ -123,7 +121,6 @@ if (els.geohash) {
     handleGeohashInput();
     updateGeohashFromLatLon();
   });
-  updateGeohashRegionDisplay(els.geohash.value);
 }
 initGeolocationButton();
 
@@ -313,29 +310,6 @@ function disableWhile(el, fn) {
   })();
 }
 
-function updateGeohashRegionDisplay(value) {
-  const target = els.geohashRegion;
-  if (!target) return;
-  const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
-  const region = lookupRegionForGeohash(normalized);
-  let label = target.querySelector('strong');
-  if (!label) {
-    label = document.createElement('strong');
-    label.textContent = 'Region:';
-    target.textContent = '';
-    target.appendChild(label);
-  } else {
-    label.textContent = 'Region:';
-  }
-  const textValue = region || '—';
-  if (label.nextSibling) {
-    label.nextSibling.textContent = ` ${textValue}`;
-  } else {
-    target.appendChild(document.createTextNode(` ${textValue}`));
-  }
-  target.dataset.regionState = region ? 'known' : 'unknown';
-}
-
 function updateGeohashFromLatLon() {
   if (!els.lat || !els.lon) return;
   if (locationUpdateSource === 'geohash') return;
@@ -346,7 +320,6 @@ function updateGeohashFromLatLon() {
     if (els.geohash && locationUpdateSource !== 'geohash') {
       els.geohash.value = '';
     }
-    updateGeohashRegionDisplay('');
     return;
   }
 
@@ -358,9 +331,7 @@ function updateGeohashFromLatLon() {
       els.geohash.value = geohash;
       locationUpdateSource = null;
     }
-    updateGeohashRegionDisplay(geohash);
   } catch {
-    updateGeohashRegionDisplay('');
   }
 }
 
@@ -374,11 +345,9 @@ function handleGeohashInput() {
   }
 
   if (!raw) {
-    updateGeohashRegionDisplay('');
     return;
   }
 
-  updateGeohashRegionDisplay(raw);
   if (locationUpdateSource === 'latlon') return;
 
   try {

--- a/js/tenant.js
+++ b/js/tenant.js
@@ -2,7 +2,6 @@ import { sdk } from 'https://esm.sh/@farcaster/miniapp-sdk';
 import { encodeFunctionData, erc20Abi, createPublicClient, http } from 'https://esm.sh/viem@2.9.32';
 import { arbitrum } from 'https://esm.sh/viem/chains';
 import { bytes32ToCastHash, buildFarcasterCastUrl, geohashToLatLon } from './tools.js';
-import { lookupRegionForGeohash } from './georegions.js';
 import { notify, mountNotificationCenter } from './notifications.js';
 import createBackController from './back-navigation.js';
 import {
@@ -573,7 +572,6 @@ async function fetchListingInfo(listingAddr){
     );
     let lat = null;
     let lon = null;
-    const region = lookupRegionForGeohash(geohash);
     if (geohash) {
       try {
         const coords = geohashToLatLon(geohash);
@@ -601,7 +599,6 @@ async function fetchListingInfo(listingAddr){
       geohashPrecision,
       lat,
       lon,
-      region,
       landlord,
     };
   } catch (err) {
@@ -665,13 +662,6 @@ function renderListingCard(info){
       label.textContent = 'Location: —';
     }
     geoLine.appendChild(label);
-
-    if (info.region) {
-      const regionTag = document.createElement('span');
-      regionTag.className = 'geo-region-tag';
-      regionTag.textContent = info.region;
-      geoLine.appendChild(regionTag);
-    }
 
     if (preciseCoords) {
       const copyBtn = document.createElement('button');

--- a/landlord.html
+++ b/landlord.html
@@ -111,9 +111,6 @@
     button.inline-button.location-detect { background:#6366f1; }
     .location-tip { margin-top:8px; font-size:.8rem; }
     .location-tip a { color:#1f6feb; text-decoration:underline; }
-    .geohash-region { margin-top:4px; font-size:.8rem; color:#475569; }
-    .geohash-region strong { font-weight:600; color:#0f172a; }
-    .geohash-region[data-region-state='known'] { color:#047857; }
     footer { margin-top:32px; padding-top:12px; border-top:1px solid var(--stroke, #e2e8f0); font-size:.9rem; color:var(--muted, #475569); text-align:center; }
   </style>
   <script src="./js/dev-settings.js"></script>
@@ -217,7 +214,6 @@
           <span class="field-title">GeoHash</span>
           <span class="field-hint">We derive this automatically. Paste one to update the coordinates.</span>
           <input id="geohash" placeholder="thrr3sq" autocapitalize="off" spellcheck="false">
-          <div class="geohash-region" id="geohashRegion" aria-live="polite"><strong>Region:</strong> —</div>
         </div>
       </label>
     </div>

--- a/tenant.html
+++ b/tenant.html
@@ -35,7 +35,6 @@
     .listing-title { font-weight:600; font-size:1rem; }
     .listing-summary { color:#475569; }
     .listing-geo { display:flex; flex-wrap:wrap; gap:8px; align-items:center; }
-    .geo-region-tag { background:#ecfdf5; color:#047857; border-radius:999px; padding:2px 8px; font-size:.75rem; font-weight:600; }
     button.inline-button { width:auto; padding:8px 12px; font-size:.8rem; border-radius:8px; border:1px solid #bfdbfe; background:#dbeafe; color:#1d4ed8; }
     button.inline-button:disabled { opacity:.6; cursor:not-allowed; }
     .geo-map-link { color:#0369a1; font-weight:600; text-decoration:none; }


### PR DESCRIPTION
## Summary
- remove the coarse region display from the landlord geohash field so the form focuses on coordinates
- drop geohash region lookups from landlord and tenant scripts to limit functionality to lat/lon conversions
- clean up the tenant listing styles after removing the region badge

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf856dcc2c832abcc086475a2338be