### PR TITLE
Fix tenant booking enumeration off-by-one

### DIFF
--- a/js/tenant.js
+++ b/js/tenant.js
@@ -1557,8 +1557,8 @@ async function loadTenantBookings(account, options = {}) {
       const entry = nextResults[i];
       if (!entry || entry.status !== 'success') continue;
       const nextId = toBigInt(entry.result, 0n);
-      if (nextId <= 1n) continue;
-      for (let id = 1n; id < nextId; id += 1n) {
+      if (nextId === 0n) continue;
+      for (let id = 1n; id <= nextId; id += 1n) {
         bookingMetas.push({ listing: cleaned[i], bookingId: id });
       }
     }


### PR DESCRIPTION
## Summary
- iterate tenant booking lookups through the full nextBookingId range
- keep zero as the only sentinel so first bookings are still discovered

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68d15aa366d4832a9c853d1f7f98cbef