### PR TITLE
Show tokenisation metadata in booking views

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1131,6 +1131,29 @@ dl.summary-breakdown dd {
   font-size: 0.9rem;
 }
 
+.booking-tokenisation-section {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.booking-tokenisation-title {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+  font-weight: 600;
+}
+
+.booking-tokenisation-empty {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  font-weight: 500;
+}
+
 .booking-detail-label {
   font-size: 0.72rem;
   text-transform: uppercase;


### PR DESCRIPTION
## Summary
- carry tokenisation supply, pricing, fee and period fields through the tenant booking record and render them in a dedicated card section
- display the same tokenisation snapshot within the landlord deposit loader output
- add styling so the new tokenisation rows align with the existing booking detail grid

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3359381f0832a86e9018037e8bd1a