### PR TITLE
Handle pending tokenisation approvals

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1201,6 +1201,15 @@ dl.summary-breakdown dd {
   font-weight: 500;
 }
 
+.booking-tokenisation-alert {
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: var(--color-warning-bg);
+  color: var(--color-warning-text);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
 .booking-detail-label {
   font-size: 0.72rem;
   text-transform: uppercase;


### PR DESCRIPTION
## Summary
- read pending tokenisation proposals when loading tenant bookings and surface them in each booking record
- show a waiting-for-approval banner on tenant booking cards and suppress tokenisation actions while a proposal is pending
- refresh landlord token tools with the same pending state handling and introduce a shared alert style

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d3409c4c9c832ab601a354bc6e1ed6