### PR TITLE
Restore investor token selection flow

### DIFF
--- a/investor.html
+++ b/investor.html
@@ -51,6 +51,71 @@
     </div>
   </section>
 
+  <section class="card" id="investCard" hidden>
+    <h2>Invest in a tokenised booking</h2>
+    <p class="muted">Select a booking from the tokenisation overview to load investment details.</p>
+    <div id="investDetails" hidden>
+      <div class="invest-summary">
+        <div class="invest-summary-details">
+          <div class="listing-title" id="investProperty"></div>
+          <div class="invest-address muted">Listing <span id="investListingAddress" class="mono"></span></div>
+        </div>
+        <div id="investBooking"></div>
+      </div>
+      <div id="investDescription" class="listing-summary" hidden></div>
+      <div class="metric-row">
+        <div class="metric">
+          <label>Price per SQMU</label>
+          <span id="investPrice">0 USDC</span>
+        </div>
+        <div class="metric">
+          <label>Remaining supply</label>
+          <span id="investRemaining">0 SQMU-R</span>
+        </div>
+        <div class="metric">
+          <label>Platform fee</label>
+          <span id="investFeeBps">0 bps</span>
+        </div>
+        <div class="metric">
+          <label>Rent cadence</label>
+          <span id="investPeriod">—</span>
+        </div>
+      </div>
+      <form id="investForm" class="form-grid">
+        <label for="investSqmuInput">SQMU amount</label>
+        <input
+          type="number"
+          id="investSqmuInput"
+          min="1"
+          step="1"
+          inputmode="numeric"
+          pattern="[0-9]*"
+          placeholder="Enter SQMU amount"
+          required
+        />
+        <div id="investInputHint" class="invest-amount-hint"></div>
+        <div class="metric-row">
+          <div class="metric">
+            <label>Total cost</label>
+            <span id="investTotal">0 USDC</span>
+          </div>
+          <div class="metric">
+            <label>Platform fee</label>
+            <span id="investFee">0 USDC</span>
+          </div>
+          <div class="metric">
+            <label>Net to landlord</label>
+            <span id="investNet">0 USDC</span>
+          </div>
+        </div>
+        <div class="actions">
+          <button type="submit" id="investSubmit" disabled>Invest</button>
+          <button type="button" class="secondary" id="investCancel">Cancel</button>
+        </div>
+      </form>
+    </div>
+  </section>
+
   <section class="card">
     <h2>Rent accrual</h2>
     <p>Claimable rent across your SQMU-R holdings. Claim in a single click when available.</p>

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -838,6 +838,21 @@ footer {
   box-shadow: var(--shadow-subtle);
 }
 
+.data-card.selectable {
+  cursor: pointer;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast), transform var(--transition-fast);
+}
+
+.data-card.selectable:hover {
+  border-color: var(--color-selected-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.data-card.is-selected {
+  border-color: var(--color-selected-border);
+  box-shadow: var(--color-selected-shadow);
+}
+
 .landlord-card-summary {
   display: flex;
   align-items: center;
@@ -1300,6 +1315,42 @@ dl.summary-breakdown dd {
 .listing-summary {
   color: var(--color-muted);
   font-size: 0.9rem;
+}
+
+.invest-summary {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.invest-summary-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.invest-summary .badge-with-copy {
+  flex-shrink: 0;
+}
+
+.invest-address {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.invest-address .mono {
+  color: var(--color-heading);
+}
+
+.invest-amount-hint {
+  font-size: 0.8rem;
+  color: var(--color-muted);
 }
 
 .listing-geo {


### PR DESCRIPTION
## Summary
- make tokenisation cards selectable and highlight the active booking so the invest form syncs with the chosen booking
- disable investing when no SQMU is available and keep holdings cards informational-only to avoid confusing selection states

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d3497ba50c832aba37bd6c14bffc3a