### PR TITLE
Add landlord and platform tokenisation dashboards

### DIFF
--- a/js/abi/Listing.json
+++ b/js/abi/Listing.json
@@ -18,6 +18,19 @@
     {
       "inputs": [
         {
+          "internalType": "uint256",
+          "name": "bookingId",
+          "type": "uint256"
+        }
+      ],
+      "name": "rejectTokenisation",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
           "internalType": "uint64",
           "name": "start",
           "type": "uint64"
@@ -743,6 +756,31 @@
         }
       ],
       "name": "TokenisationApproved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "bookingId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "rejector",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "proposer",
+          "type": "address"
+        }
+      ],
+      "name": "TokenisationRejected",
       "type": "event"
     },
     {

--- a/platform.html
+++ b/platform.html
@@ -74,6 +74,16 @@
     </form>
   </section>
 
+  <section class="card" id="tokenisationSection" data-owner-only hidden>
+    <h2>Tokenisation approvals</h2>
+    <p class="muted">Review pending tokenisation proposals from landlords. Approve or reject each booking before investors can participate.</p>
+    <div class="button-row">
+      <button type="button" id="tokenRefreshBtn" class="secondary" disabled>Refresh proposals</button>
+    </div>
+    <div class="note status status-info" id="tokenProposalStatus">Connect the owner wallet to load tokenisation proposals.</div>
+    <div id="tokenProposalList" class="data-list"></div>
+  </section>
+
   <section class="card" id="listingLifecycleSection" data-owner-only hidden>
     <h2>Listing lifecycle</h2>
     <p class="muted">Emergency owner controls for managing live listings.</p>

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1256,6 +1256,21 @@ dl.summary-breakdown dd {
   color: var(--color-muted);
 }
 
+.landlord-bookings-card {
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 12px;
+  background: rgba(248, 249, 254, 0.6);
+}
+
+.landlord-bookings-card .bookings-header h3 {
+  margin: 0;
+}
+
+.landlord-bookings-card .bookings-status {
+  margin-top: -4px;
+}
+
 .data-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- surface landlord booking details with tokenisation status, SQMU progress, and quick actions
- add platform dashboard for reviewing and approving or rejecting tokenisation proposals
- extend Listing contract/ABI with tokenisation rejection support for the new controls

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d34f88edf0832a8e8436438b7e9757