### PR TITLE
Remove landlord weekly/monthly pricing inputs

### DIFF
--- a/js/landlord.js
+++ b/js/landlord.js
@@ -89,8 +89,6 @@ const els = {
   deposit: document.getElementById('deposit'),
   areaSqm: document.getElementById('areaSqm'),
   rateDaily: document.getElementById('rateDaily'),
-  rateWeekly: document.getElementById('rateWeekly'),
-  rateMonthly: document.getElementById('rateMonthly'),
   minNotice: document.getElementById('minNotice'),
   maxWindow: document.getElementById('maxWindow'),
   metadataUrl: document.getElementById('metadataUrl'),
@@ -203,8 +201,6 @@ const onboardingFields = [
   'areaSqm',
   'deposit',
   'rateDaily',
-  'rateWeekly',
-  'rateMonthly',
   'minNotice',
   'maxWindow',
 ];
@@ -536,8 +532,6 @@ function buildMetadataUri(params) {
     areaSqm,
     deposit,
     rateDaily,
-    rateWeekly,
-    rateMonthly,
     fid,
     castHash,
     minBookingNotice,
@@ -561,8 +555,6 @@ function buildMetadataUri(params) {
     deposit: deposit.toString(),
     rates: {
       daily: rateDaily.toString(),
-      weekly: rateWeekly.toString(),
-      monthly: rateMonthly.toString(),
     },
     bookingWindow: {
       minNoticeSeconds: minBookingNotice.toString(),
@@ -735,9 +727,7 @@ function evaluateOnboardingSteps() {
   try {
     const deposit = parseDec6(els.deposit.value);
     const daily = parseOptionalDec6(els.rateDaily.value);
-    const weekly = parseOptionalDec6(els.rateWeekly.value);
-    const monthly = parseOptionalDec6(els.rateMonthly.value);
-    results.pricing = deposit > 0n && (daily > 0n || weekly > 0n || monthly > 0n);
+    results.pricing = deposit > 0n && daily > 0n;
   } catch {
     results.pricing = false;
   }
@@ -759,7 +749,7 @@ function updateOnboardingProgress() {
 
   if (!results.basics) hints.push('Add a title and short description.');
   if (!results.location) hints.push('Provide latitude, longitude and area.');
-  if (!results.pricing) hints.push('Set a deposit and at least one rent rate.');
+  if (!results.pricing) hints.push('Set a deposit and daily rent rate.');
   if (!results.policies) hints.push('Configure booking notice and window.');
 
   if (els.onboardingHints) {
@@ -2887,8 +2877,8 @@ els.create.onclick = () =>
 
       const deposit = parseDec6(els.deposit.value);
       const rateDaily = parseOptionalDec6(els.rateDaily.value);
-      const rateWeekly = parseOptionalDec6(els.rateWeekly.value);
-      const rateMonthly = parseOptionalDec6(els.rateMonthly.value);
+      if (deposit <= 0n) throw new Error('Deposit must be greater than zero.');
+      if (rateDaily <= 0n) throw new Error('Daily rate must be greater than zero.');
 
       const { lat, lon } = parseLatLon(els.lat.value, els.lon.value);
       const geohashStr = latLonToGeohash(lat, lon, GEOHASH_PRECISION);
@@ -2943,8 +2933,6 @@ els.create.onclick = () =>
         areaSqm,
         deposit,
         rateDaily,
-        rateWeekly,
-        rateMonthly,
         fid: fidBig,
         castHash,
         minBookingNotice,

--- a/landlord.html
+++ b/landlord.html
@@ -151,7 +151,7 @@
 
   <div class="guided-section">
     <h3>2. Pricing & size</h3>
-    <p class="section-subtext">Share the deposit, footprint and daily/weekly/monthly rates you want to accept.</p>
+    <p class="section-subtext">Share the deposit, footprint and daily rate you want to accept.</p>
     <div class="field-grid columns-2">
       <label class="field-option">
         <span class="status-dot" aria-hidden="true"></span>
@@ -170,29 +170,13 @@
         </div>
       </label>
     </div>
-    <div class="field-grid columns-3">
+    <div class="field-grid">
       <label class="field-option">
         <span class="status-dot" aria-hidden="true"></span>
         <div class="field-content">
           <span class="field-title">Daily (USDC)</span>
-          <span class="field-hint">Enter 0 to disable daily pricing.</span>
-          <input id="rateDaily"  value="0" inputmode="decimal">
-        </div>
-      </label>
-      <label class="field-option">
-        <span class="status-dot" aria-hidden="true"></span>
-        <div class="field-content">
-          <span class="field-title">Weekly (USDC)</span>
-          <span class="field-hint">Enter 0 to disable weekly pricing.</span>
-          <input id="rateWeekly" value="0" inputmode="decimal">
-        </div>
-      </label>
-      <label class="field-option">
-        <span class="status-dot" aria-hidden="true"></span>
-        <div class="field-content">
-          <span class="field-title">Monthly (USDC)</span>
-          <span class="field-hint">Enter 0 to disable monthly pricing.</span>
-          <input id="rateMonthly" value="0" inputmode="decimal">
+          <span class="field-hint">Required — sets the on-chain price per day.</span>
+          <input id="rateDaily" value="0" inputmode="decimal">
         </div>
       </label>
     </div>


### PR DESCRIPTION
## Summary
- remove the weekly and monthly pricing inputs from the landlord listing form and copy
- update landlord onboarding logic to require a daily rate and persist only the daily value in metadata
- add guards that prevent deploying listings without a deposit or daily rate

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d3ee1dcea8832aba66fd1a262451f0