### PR TITLE
Use responsive grid for listing containers

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -658,10 +658,11 @@ footer {
 }
 
 #landlordListings,
-#listings {
+#listings,
+#bookingsList {
   margin-top: 12px;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 12px;
 }
 


### PR DESCRIPTION
## Summary
- switch the landlord listings and listings containers to a responsive CSS grid
- include the bookings list container in the same grid styling for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d46b1ba6c0832ab26c0e74dc60b2d8