### PR TITLE
Add layout and collapsible styles

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1565,3 +1565,29 @@ section.card:not([hidden]),
     scroll-behavior: auto !important;
   }
 }
+
+.card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.card-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+[data-collapsible] .inline-button {
+  font-weight: 600;
+}
+
+[data-collapsible-content][hidden] {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- add flexbox layout helpers for card headers, metadata, and actions
- tighten inline button weight and hidden handling for collapsible sections

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4764aa6a0832ab17da68f8272df25