### PR TITLE
Refine tenant and landlord cards with shared formatting

### DIFF
--- a/js/ui/accordion.js
+++ b/js/ui/accordion.js
@@ -11,3 +11,33 @@ export function makeCollapsible(section) {
   // default: collapsed on load for long pages
   setOpen(false);
 }
+
+export function createCollapsibleSection(label, { id, classes = [] } = {}) {
+  const section = document.createElement('section');
+  section.className = ['card', ...classes].filter(Boolean).join(' ');
+  section.dataset.collapsible = '';
+  if (id) section.id = id;
+
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.className = 'inline-button';
+  toggle.dataset.collapsibleToggle = '';
+  toggle.setAttribute('aria-expanded', 'false');
+  toggle.textContent = label;
+  section.appendChild(toggle);
+
+  const content = document.createElement('div');
+  content.dataset.collapsibleContent = '';
+  content.hidden = true;
+  section.appendChild(content);
+
+  makeCollapsible(section);
+
+  const setOpen = (open) => {
+    section.dataset.open = open ? '1' : '0';
+    content.hidden = !open;
+    toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+  };
+
+  return { section, content, toggle, setOpen };
+}

--- a/js/ui/cards.js
+++ b/js/ui/cards.js
@@ -1,83 +1,105 @@
 import { el, fmt } from './dom.js';
 
-const Pill = (text) => el('span', { class:'pill' }, text);
+const Pill = (text) => el('span', { class: 'pill' }, text);
 
-export function ListingCard({ id, title, location, pricePerDayUSDC, areaSqm, depositUSDC, status, actions=[] }) {
-  return el('div', { class:'card listing-card', dataset:{ id } }, [
-    el('div', { class:'card-header' }, [
+const periodLabel = (value) => {
+  if (value === undefined || value === null || value === '') return '—';
+  const label = fmt.period(value);
+  if (label) return label;
+  return typeof value === 'string' ? value : String(value);
+};
+
+export function ListingCard({ id, title, location, pricePerDayUSDC, areaSqm, depositUSDC, status, actions = [] }) {
+  return el('div', { class: 'card listing-card', dataset: { id } }, [
+    el('div', { class: 'card-header' }, [
       el('strong', {}, title || `Listing #${id}`),
-      el('div', { class:'card-meta' }, [
+      el('div', { class: 'card-meta' }, [
         Pill(location || '—'),
-        Pill(`Daily ${fmt.money(pricePerDayUSDC)} USDC`),
-        Pill(fmt.sqm(areaSqm || '—')),
-        depositUSDC!=null ? Pill(`Deposit ${fmt.money(depositUSDC)}`) : null,
+        pricePerDayUSDC != null ? Pill(`Daily ${fmt.usdc(pricePerDayUSDC)} USDC`) : null,
+        areaSqm != null ? Pill(fmt.sqm(areaSqm)) : null,
+        depositUSDC != null ? Pill(`Deposit ${fmt.usdc(depositUSDC)} USDC`) : null,
         status ? Pill(status) : null,
-      ].filter(Boolean))
+      ].filter(Boolean)),
     ]),
-    el('div', { class:'card-actions' },
-      actions.filter(a => a?.visible !== false).map(a =>
-        el('button', { class:'inline-button', onClick:a.onClick }, a.label)
-      )
-    )
+    el(
+      'div',
+      { class: 'card-actions' },
+      actions
+        .filter((a) => a?.visible !== false)
+        .map((a) => el('button', { class: 'inline-button', onClick: a.onClick }, a.label)),
+    ),
   ]);
 }
 
-export function BookingCard({ bookingId, listingId, dates, period, depositUSDC, rentUSDC, status, actions=[] }) {
-  return el('div', { class:'card data-card booking-entry', dataset:{ bookingId, listingId } }, [
-    el('div', { class:'card-header' }, [
+export function BookingCard({ bookingId, listingId, dates, period, depositUSDC, rentUSDC, status, actions = [] }) {
+  return el('div', { class: 'card data-card booking-entry', dataset: { bookingId, listingId } }, [
+    el('div', { class: 'card-header' }, [
       el('strong', {}, `Booking #${bookingId}`),
-      el('div', { class:'card-meta' }, [
+      el('div', { class: 'card-meta' }, [
         Pill(dates || '—'),
-        Pill(period || '—'),
-        depositUSDC!=null ? Pill(`Deposit ${fmt.money(depositUSDC)}`) : null,
-        rentUSDC!=null ? Pill(`Rent ${fmt.money(rentUSDC)}`) : null,
+        Pill(periodLabel(period)),
+        depositUSDC != null ? Pill(`Deposit ${fmt.usdc(depositUSDC)} USDC`) : null,
+        rentUSDC != null ? Pill(`Rent ${fmt.usdc(rentUSDC)} USDC`) : null,
         status ? Pill(status) : null,
-      ].filter(Boolean))
+      ].filter(Boolean)),
     ]),
-    el('div', { class:'card-actions' },
-      actions.filter(a => a?.visible !== false).map(a =>
-        el('button', { class:'inline-button', onClick:a.onClick }, a.label)
-      )
-    )
+    el(
+      'div',
+      { class: 'card-actions' },
+      actions
+        .filter((a) => a?.visible !== false)
+        .map((a) => el('button', { class: 'inline-button', onClick: a.onClick }, a.label)),
+    ),
   ]);
 }
 
-export function TokenisationCard({ bookingId, totalSqmu, soldSqmu, pricePerSqmu, feeBps, period, mode='invest', onSubmit }) {
-  const form = el('form', { class:'token-proposal-card card' }, [
+export function TokenisationCard({ bookingId, totalSqmu, soldSqmu, pricePerSqmu, feeBps, period, mode = 'invest', onSubmit }) {
+  const form = el('form', { class: 'token-proposal-card card' }, [
     el('h3', {}, mode === 'propose' ? 'Propose tokenisation' : 'Invest in SQMU-R'),
-    el('div', { class:'card-meta' }, [
+    el('div', { class: 'card-meta' }, [
       Pill(`Booking #${bookingId}`),
-      totalSqmu!=null ? Pill(`Total ${totalSqmu} SQMU`) : null,
-      soldSqmu!=null  ? Pill(`Sold ${soldSqmu}`) : null,
-      pricePerSqmu!=null ? Pill(`Price ${fmt.money(pricePerSqmu)} USDC`) : null,
-      feeBps!=null ? Pill(`${feeBps} bps`) : null,
-      period ? Pill(period) : null,
+      totalSqmu != null ? Pill(`Total ${fmt.sqmu(totalSqmu)} SQMU`) : null,
+      soldSqmu != null ? Pill(`Sold ${fmt.sqmu(soldSqmu)}`) : null,
+      pricePerSqmu != null ? Pill(`Price ${fmt.usdc(pricePerSqmu)} USDC`) : null,
+      feeBps != null ? Pill(fmt.bps(feeBps)) : null,
+      period ? Pill(periodLabel(period)) : null,
     ].filter(Boolean)),
     el('label', {}, [
       el('span', {}, mode === 'propose' ? 'Total SQMU' : 'Amount (SQMU)'),
-      el('input', { name:'amount', type:'number', step:'1', min:'1', required:true })
+      el('input', { name: 'amount', type: 'number', step: '1', min: '1', required: true }),
     ]),
-    mode === 'propose' ? el('label', {}, [
-      el('span', {}, 'Price per SQMU (USDC)'),
-      el('input', { name:'price', type:'number', step:'0.000001', min:'0', required:true })
-    ]) : null,
-    mode === 'propose' ? el('label', {}, [
-      el('span', {}, 'Platform fee (bps)'),
-      el('input', { name:'fee', type:'number', step:'1', min:'0', max:'10000', required:true })
-    ]) : null,
-    mode === 'propose' ? el('label', {}, [
-      el('span', {}, 'Distribution period'),
-      el('select', { name:'period', required:true }, [
-        el('option', { value:'day'  }, 'Daily'),
-        el('option', { value:'week' }, 'Weekly'),
-        el('option', { value:'month'}, 'Monthly'),
-      ])
-    ]) : null,
-    el('div', { class:'card-actions' }, [
-      el('button', { type:'submit', class:'inline-button' }, mode === 'propose' ? 'Submit proposal' : 'Invest')
-    ])
+    mode === 'propose'
+      ? el('label', {}, [
+          el('span', {}, 'Price per SQMU (USDC)'),
+          el('input', { name: 'price', type: 'number', step: '0.000001', min: '0', required: true }),
+        ])
+      : null,
+    mode === 'propose'
+      ? el('label', {}, [
+          el('span', {}, 'Platform fee (bps)'),
+          el('input', { name: 'fee', type: 'number', step: '1', min: '0', max: '10000', required: true }),
+        ])
+      : null,
+    mode === 'propose'
+      ? el('label', {}, [
+          el('span', {}, 'Distribution period'),
+          el('select', { name: 'period', required: true }, [
+            el('option', { value: 'day' }, 'Daily'),
+            el('option', { value: 'week' }, 'Weekly'),
+            el('option', { value: 'month' }, 'Monthly'),
+          ]),
+        ])
+      : null,
+    el('div', { class: 'card-actions' }, [
+      el('button', { type: 'submit', class: 'inline-button' }, mode === 'propose' ? 'Submit proposal' : 'Invest'),
+    ]),
   ].filter(Boolean));
 
-  if (onSubmit) form.addEventListener('submit', (e) => { e.preventDefault(); const fd = new FormData(form); onSubmit(Object.fromEntries(fd)); });
+  if (onSubmit)
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const fd = new FormData(form);
+      onSubmit(Object.fromEntries(fd));
+    });
   return form;
 }

--- a/js/ui/dom.js
+++ b/js/ui/dom.js
@@ -9,7 +9,165 @@ export const el = (tag, props={}, children=[]) => {
   (Array.isArray(children) ? children : [children]).forEach(c => node.append(c?.nodeType ? c : document.createTextNode(String(c ?? ''))));
   return node;
 };
+
+const USDC_DECIMALS = 6;
+
+const PERIOD_LABELS = new Map([
+  ['day', 'Daily'],
+  ['week', 'Weekly'],
+  ['month', 'Monthly'],
+  ['0', 'Unspecified'],
+  ['1', 'Daily'],
+  ['2', 'Weekly'],
+  ['3', 'Monthly'],
+]);
+
+const toBigIntSafe = (value) => {
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || Number.isNaN(value)) return null;
+    return BigInt(Math.trunc(value));
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    try {
+      return BigInt(trimmed);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+};
+
+const formatBigIntWithDecimals = (value, decimals = USDC_DECIMALS) => {
+  const negative = value < 0n;
+  const abs = negative ? -value : value;
+  const units = abs / (10n ** BigInt(decimals));
+  const remainder = (abs % (10n ** BigInt(decimals))).toString().padStart(decimals, '0').replace(/0+$/, '');
+  const base = `${units.toString()}${remainder ? `.${remainder}` : ''}`;
+  return negative ? `-${base}` : base;
+};
+
+const formatInteger = (value) => {
+  if (typeof value === 'bigint') {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric) && Math.abs(numeric) <= Number.MAX_SAFE_INTEGER) {
+      return numeric.toLocaleString('en-US');
+    }
+    return value.toString();
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || Number.isNaN(value)) return '0';
+    return Math.trunc(value).toLocaleString('en-US');
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return Math.trunc(parsed).toLocaleString('en-US');
+    return value;
+  }
+  return '0';
+};
+
+const formatDurationSeconds = (seconds) => {
+  const value = toBigIntSafe(seconds) ?? 0n;
+  if (value <= 0n) return 'None';
+  const totalSeconds = Number(value);
+  if (!Number.isFinite(totalSeconds)) return `${value.toString()} sec`;
+  const days = Math.floor(totalSeconds / 86400);
+  const remainder = totalSeconds % 86400;
+  if (days > 0 && remainder === 0) {
+    return `${days} day${days === 1 ? '' : 's'}`;
+  }
+  if (days > 0) {
+    const hours = Math.round(remainder / 3600);
+    if (hours === 0) {
+      return `${days} day${days === 1 ? '' : 's'}`;
+    }
+    return `${days} day${days === 1 ? '' : 's'} ${hours} h`;
+  }
+  const hoursOnly = Math.max(1, Math.round(totalSeconds / 3600));
+  return `${hoursOnly} hour${hoursOnly === 1 ? '' : 's'}`;
+};
+
+const formatTimestampSeconds = (seconds, { isoDate = false } = {}) => {
+  const value = toBigIntSafe(seconds);
+  if (!value || value <= 0n) return '';
+  let numeric;
+  try {
+    numeric = Number(value);
+  } catch {
+    return `Unix ${value.toString()}`;
+  }
+  if (!Number.isFinite(numeric) || Number.isNaN(numeric)) {
+    return `Unix ${value.toString()}`;
+  }
+  const date = new Date(numeric * 1000);
+  if (Number.isNaN(date.getTime())) {
+    return `Unix ${value.toString()}`;
+  }
+  if (isoDate) {
+    return date.toISOString().slice(0, 10);
+  }
+  return `${date.toISOString().replace('T', ' ').slice(0, 16)} UTC`;
+};
+
+const formatBasisPoints = (value) => {
+  const raw = toBigIntSafe(value);
+  if (raw === null) return '0 bps';
+  const numeric = Number(raw);
+  if (!Number.isFinite(numeric)) {
+    return `${raw.toString()} bps`;
+  }
+  const percent = (numeric / 100).toFixed(2).replace(/\.0+$/, '').replace(/\.([1-9])0$/, '.$1');
+  return `${percent}% (${raw.toString()} bps)`;
+};
+
+const resolvePeriodLabel = (value) => {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (PERIOD_LABELS.has(normalized)) {
+      return PERIOD_LABELS.get(normalized);
+    }
+    if (/^\d+$/.test(normalized) && PERIOD_LABELS.has(normalized)) {
+      return PERIOD_LABELS.get(normalized);
+    }
+  }
+  const asBigInt = toBigIntSafe(value);
+  if (asBigInt !== null) {
+    const label = PERIOD_LABELS.get(asBigInt.toString());
+    if (label) return label;
+  }
+  return '';
+};
+
+const formatUsdc = (value) => {
+  if (value === undefined || value === null) return '0';
+  if (typeof value === 'bigint') {
+    return formatBigIntWithDecimals(value, USDC_DECIMALS);
+  }
+  const asBigInt = toBigIntSafe(value);
+  if (asBigInt !== null) {
+    return formatBigIntWithDecimals(asBigInt, USDC_DECIMALS);
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || Number.isNaN(numeric)) {
+    return '0';
+  }
+  return new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: USDC_DECIMALS,
+  }).format(numeric);
+};
+
 export const fmt = {
-  money: (n) => new Intl.NumberFormat(undefined, {minimumFractionDigits:2, maximumFractionDigits:6}).format(Number(n || 0)),
-  sqm:   (n) => `${n} m²`,
+  money: (value) => formatUsdc(value),
+  usdc: (value) => formatUsdc(value),
+  sqm:   (n) => `${formatInteger(n)} m²`,
+  sqmu:  (value) => formatInteger(value),
+  duration: (seconds) => formatDurationSeconds(seconds),
+  timestamp: (seconds) => formatTimestampSeconds(seconds),
+  date: (seconds) => formatTimestampSeconds(seconds, { isoDate: true }) || '—',
+  bps: (value) => formatBasisPoints(value),
+  period: (value) => resolvePeriodLabel(value) || '—',
 };


### PR DESCRIPTION
## Summary
- centralize money, period, and date formatting helpers in js/ui/dom.js and update card components to consume BigInt-friendly values
- refactor landlord listing rendering to use BookingCard with collapsible availability, bookings, deposit, and tokenisation panels
- embed tenant tokenisation proposals directly in booking cards via accordion panels and reuse shared formatting utilities

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d478ad39fc832aae5cbee3a28893d2