### PR TITLE
Improve collapsible controls visibility across dashboards

### DIFF
--- a/js/landlord.js
+++ b/js/landlord.js
@@ -6,7 +6,7 @@ import { requestWalletSendCalls, isUserRejectedRequestError } from './wallet.js'
 import { notify, mountNotificationCenter } from './notifications.js';
 import { ListingCard, BookingCard, TokenisationCard } from './ui/cards.js';
 import { actionsFor } from './ui/actions.js';
-import { createCollapsibleSection } from './ui/accordion.js';
+import { createCollapsibleSection, mountCollapsibles } from './ui/accordion.js';
 import { el, fmt } from './ui/dom.js';
 import {
   PLATFORM_ADDRESS,
@@ -114,6 +114,7 @@ if (els.connect && !els.connect.dataset.defaultLabel) {
 const info = (t) => (els.status.textContent = t);
 
 mountNotificationCenter(document.getElementById('notificationTray'), { role: 'landlord' });
+mountCollapsibles();
 
 const listingUiControllers = new Map();
 let quickAuthReady = false;

--- a/js/tenant.js
+++ b/js/tenant.js
@@ -7,7 +7,7 @@ import { notify, mountNotificationCenter } from './notifications.js';
 import createBackController from './back-navigation.js';
 import { ListingCard, BookingCard, TokenisationCard } from './ui/cards.js';
 import { actionsFor } from './ui/actions.js';
-import { createCollapsibleSection } from './ui/accordion.js';
+import { createCollapsibleSection, mountCollapsibles } from './ui/accordion.js';
 import { el, fmt } from './ui/dom.js';
 import {
   RPC_URL,
@@ -86,6 +86,7 @@ let activeTokenProposalPanel = null;
 let activeTokenProposalCard = null;
 
 mountNotificationCenter(document.getElementById('notificationTray'), { role: 'tenant' });
+mountCollapsibles();
 
 const backButton = document.querySelector('[data-back-button]');
 const backController = createBackController({ sdk, button: backButton });

--- a/js/ui/accordion.js
+++ b/js/ui/accordion.js
@@ -1,15 +1,73 @@
-export function makeCollapsible(section) {
+const COLLAPSIBLE_CONTROL = Symbol('collapsibleControl');
+let nextCollapsibleId = 0;
+
+function toBoolean(value, fallback = false) {
+  if (value === undefined || value === null) return fallback;
+  if (value === true || value === false) return value;
+  if (typeof value === 'string') {
+    const lowered = value.toLowerCase();
+    if (lowered === '1' || lowered === 'true' || lowered === 'yes') return true;
+    if (lowered === '0' || lowered === 'false' || lowered === 'no') return false;
+  }
+  return fallback;
+}
+
+export function makeCollapsible(section, { defaultOpen } = {}) {
+  if (!section) return null;
+  if (section[COLLAPSIBLE_CONTROL]) {
+    return section[COLLAPSIBLE_CONTROL];
+  }
+
   const content = section.querySelector('[data-collapsible-content]');
   const toggle  = section.querySelector('[data-collapsible-toggle]');
-  if (!content || !toggle) return;
+  if (!content || !toggle) return null;
+
+  if (!content.id) {
+    nextCollapsibleId += 1;
+    content.id = `collapsible-${nextCollapsibleId}`;
+  }
+  toggle.setAttribute('aria-controls', content.id);
+
   const setOpen = (open) => {
-    section.dataset.open = open ? '1' : '0';
-    content.hidden = !open;
-    toggle.setAttribute('aria-expanded', String(open));
+    const next = Boolean(open);
+    section.dataset.open = next ? '1' : '0';
+    content.hidden = !next;
+    toggle.setAttribute('aria-expanded', next ? 'true' : 'false');
   };
-  toggle.addEventListener('click', () => setOpen(content.hidden));
-  // default: collapsed on load for long pages
-  setOpen(false);
+
+  const handleToggle = () => setOpen(content.hidden);
+  const handleKey = (event) => {
+    if (event.key === ' ' || event.key === 'Spacebar' || event.key === 'Enter') {
+      event.preventDefault();
+      setOpen(content.hidden);
+    }
+  };
+
+  toggle.addEventListener('click', handleToggle);
+  toggle.addEventListener('keydown', handleKey);
+
+  const initialOpen =
+    toBoolean(defaultOpen, null) ??
+    (section.dataset.open ? section.dataset.open === '1' : null) ??
+    (toggle.getAttribute('aria-expanded') === 'true' ? true : null) ??
+    !content.hidden;
+
+  setOpen(Boolean(initialOpen));
+
+  const control = { section, content, toggle, setOpen };
+  section[COLLAPSIBLE_CONTROL] = control;
+  section.dataset.collapsibleBound = '1';
+  return control;
+}
+
+export function mountCollapsibles(root) {
+  const target = root ?? (typeof document !== 'undefined' ? document : null);
+  if (!target || typeof target.querySelectorAll !== 'function') {
+    return [];
+  }
+  return Array.from(target.querySelectorAll('[data-collapsible]'))
+    .map((section) => makeCollapsible(section))
+    .filter(Boolean);
 }
 
 export function createCollapsibleSection(label, { id, classes = [] } = {}) {
@@ -20,7 +78,7 @@ export function createCollapsibleSection(label, { id, classes = [] } = {}) {
 
   const toggle = document.createElement('button');
   toggle.type = 'button';
-  toggle.className = 'inline-button';
+  toggle.className = 'inline-button collapsible-toggle';
   toggle.dataset.collapsibleToggle = '';
   toggle.setAttribute('aria-expanded', 'false');
   toggle.textContent = label;
@@ -31,13 +89,15 @@ export function createCollapsibleSection(label, { id, classes = [] } = {}) {
   content.hidden = true;
   section.appendChild(content);
 
-  makeCollapsible(section);
+  const control = makeCollapsible(section, { defaultOpen: false }) || {};
 
-  const setOpen = (open) => {
-    section.dataset.open = open ? '1' : '0';
-    content.hidden = !open;
-    toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
-  };
+  const setOpen = control.setOpen
+    || ((open) => {
+      const next = Boolean(open);
+      section.dataset.open = next ? '1' : '0';
+      content.hidden = !next;
+      toggle.setAttribute('aria-expanded', next ? 'true' : 'false');
+    });
 
   return { section, content, toggle, setOpen };
 }

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1584,8 +1584,35 @@ section.card:not([hidden]),
   flex-wrap: wrap;
 }
 
-[data-collapsible] .inline-button {
+[data-collapsible] > .collapsible-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
   font-weight: 600;
+}
+
+[data-collapsible] > .collapsible-toggle::after {
+  content: '▾';
+  margin-left: auto;
+  font-size: 0.85rem;
+  color: var(--color-muted-strong);
+  transition: transform var(--transition-fast), color var(--transition-fast);
+}
+
+[data-collapsible][data-open='0'] > .collapsible-toggle::after {
+  transform: rotate(-90deg);
+}
+
+[data-collapsible] > .collapsible-toggle:hover::after,
+[data-collapsible] > .collapsible-toggle:focus-visible::after {
+  color: var(--color-link-hover);
+}
+
+[data-collapsible] [data-collapsible-content] {
+  margin-top: 12px;
 }
 
 [data-collapsible-content][hidden] {


### PR DESCRIPTION
## Summary
- upgrade the accordion helper with reusable controls, ARIA wiring, and a mount helper for existing sections
- style collapsible toggles so the expand/collapse affordance is clearly visible with directional chevrons
- initialise collapsible mounting on tenant and landlord pages so long tool sections load collapsed by default

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d48003d318832a924585a953f03691