### PR TITLE
Highlight cancelled bookings

### DIFF
--- a/js/landlord.js
+++ b/js/landlord.js
@@ -989,6 +989,7 @@ function renderLandlordBookingEntry(listing, record) {
     depositUSDC: record.deposit,
     rentUSDC: record.grossRent,
     status: record.statusLabel,
+    statusClass: record.statusClass,
     actions: [
       {
         label: record.tokenActionLabel,

--- a/js/tenant.js
+++ b/js/tenant.js
@@ -1046,6 +1046,9 @@ function buildBookingRecord(meta, data, pending, listingInfo) {
     : '0x0000000000000000000000000000000000000000';
   const now = BigInt(Math.floor(Date.now() / 1000));
   const isActive = statusValue === 1;
+  const isCompleted = statusValue === 2;
+  const isCancelled = statusValue === 3;
+  const isDefaulted = statusValue === 4;
   const isUpcoming = start > now;
   let canCancel = false;
   let cancelDisabledReason = '';
@@ -1093,6 +1096,9 @@ function buildBookingRecord(meta, data, pending, listingInfo) {
     listingInfo: listingInfo || null,
     canPayRent: statusValue === 1 && rentDue > 0n,
     isActive,
+    isCompleted,
+    isCancelled,
+    isDefaulted,
     canCancel,
     cancelDisabledReason,
     pendingTokenisationExists: pendingExists && !tokenised,
@@ -1591,14 +1597,23 @@ function renderBookings(records, emptyMessage = 'No bookings found for this wall
       depositUSDC: record.deposit,
       rentUSDC: record.grossRent,
       status: record.statusLabel,
+      statusClass: record.statusClass,
       actions,
     });
     card.dataset.bookingKey = record.key;
+    if (record.statusClass) {
+      card.classList.add(`booking-status-${record.statusClass}`);
+    }
     card.append(el('div', { class: 'card-footnote' }, record.listingTitle));
     const rentFootnote = record.rentDue > 0n
       ? `Outstanding rent: ${fmt.usdc(record.rentDue)} USDC`
       : 'All rent settled.';
     card.append(el('div', { class: 'card-footnote' }, rentFootnote));
+    if (record.isCancelled) {
+      card.append(el('div', { class: 'card-footnote' }, 'Booking cancelled. Record kept for reference.'));
+    } else if (record.isDefaulted) {
+      card.append(el('div', { class: 'card-footnote' }, 'Booking defaulted. Contact the platform for support.'));
+    }
     if (record.tokenised) {
       card.append(
         el('div', { class: 'card-footnote' }, `Tokenised · ${fmt.sqmu(record.totalSqmu)} SQMU · ${fmt.usdc(record.pricePerSqmu)} USDC`),

--- a/js/ui/cards.js
+++ b/js/ui/cards.js
@@ -1,6 +1,9 @@
 import { el, fmt } from './dom.js';
 
-const Pill = (text) => el('span', { class: 'pill' }, text);
+const Pill = (text, extraClass = '') => {
+  const className = extraClass ? `pill ${extraClass}` : 'pill';
+  return el('span', { class: className }, text);
+};
 
 const periodLabel = (value) => {
   if (value === undefined || value === null || value === '') return '—';
@@ -31,7 +34,17 @@ export function ListingCard({ id, title, location, pricePerDayUSDC, areaSqm, dep
   ]);
 }
 
-export function BookingCard({ bookingId, listingId, dates, period, depositUSDC, rentUSDC, status, actions = [] }) {
+export function BookingCard({
+  bookingId,
+  listingId,
+  dates,
+  period,
+  depositUSDC,
+  rentUSDC,
+  status,
+  statusClass,
+  actions = [],
+}) {
   return el('div', { class: 'card data-card booking-entry', dataset: { bookingId, listingId } }, [
     el('div', { class: 'card-header' }, [
       el('strong', {}, `Booking #${bookingId}`),
@@ -40,7 +53,14 @@ export function BookingCard({ bookingId, listingId, dates, period, depositUSDC, 
         Pill(periodLabel(period)),
         depositUSDC != null ? Pill(`Deposit ${fmt.usdc(depositUSDC)} USDC`) : null,
         rentUSDC != null ? Pill(`Rent ${fmt.usdc(rentUSDC)} USDC`) : null,
-        status ? Pill(status) : null,
+        status
+          ? Pill(
+              status,
+              ['booking-status-badge', statusClass ? `booking-status-${statusClass}` : '']
+                .filter(Boolean)
+                .join(' '),
+            )
+          : null,
       ].filter(Boolean)),
     ]),
     el(

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1162,6 +1162,11 @@ dl.summary-breakdown dd {
   color: #3f3f45;
 }
 
+.booking-status-pending {
+  background: #ede8f6;
+  color: #4a3d66;
+}
+
 .booking-status-active {
   background: #e7f0ea;
   color: #314635;


### PR DESCRIPTION
## Summary
- add booking status styling support in shared BookingCard component
- expose cancellation/default flags on tenant booking records and surface explanatory footnotes
- show consistent status badges for landlord and investor booking views and add a pending style

## Testing
- not run (UI changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d50492ff6c832a929b8459d8c7ae39