### PR TITLE
Refine tenant booking flow layout

### DIFF
--- a/js/ui/actions.js
+++ b/js/ui/actions.js
@@ -3,8 +3,16 @@ export function actionsFor({ role, entity, perms }) {
   // perms: capabilities computed from chain state
   if (entity === 'listing') {
     return [
-      { label:'Preview totals', onClick: perms.onPreview, visible: role==='tenant' },
-      { label:'Book', onClick: perms.onBook, visible: role==='tenant' && perms.bookable },
+      {
+        label: 'Preview totals',
+        onClick: perms.onPreview,
+        visible: role === 'tenant' && typeof perms.onPreview === 'function',
+      },
+      {
+        label: 'Book',
+        onClick: perms.onBook,
+        visible: role === 'tenant' && perms.bookable && typeof perms.onBook === 'function',
+      },
       { label:'Check availability', onClick: perms.onCheck, visible: role==='landlord' },
       { label: perms.active ? 'Deactivate' : 'Activate', onClick: perms.onToggleActive, visible: role==='landlord' },
       { label:'Propose tokenisation', onClick: perms.onPropose, visible: perms.canPropose },

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -657,6 +657,11 @@ footer {
   padding: 18px;
 }
 
+.planner-card-active {
+  border-color: var(--color-selected-border);
+  box-shadow: var(--color-selected-shadow);
+}
+
 #landlordListings,
 #listings,
 #bookingsList {
@@ -997,6 +1002,21 @@ footer {
   color: var(--color-pill-text);
   font-size: 0.75rem;
   margin-left: 6px;
+}
+
+.planner-layout {
+  display: grid;
+  gap: 24px;
+}
+
+.planner-listings {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.planner-form[hidden] + .planner-listings {
+  grid-column: 1 / -1;
 }
 
 .planner-grid {
@@ -1517,6 +1537,13 @@ section.card:not([hidden]),
 
 .notification-tray + * {
   animation: fadeInUp var(--transition-base) both;
+}
+
+@media (min-width: 900px) {
+  .planner-layout {
+    grid-template-columns: minmax(320px, 1fr) minmax(0, 2fr);
+    align-items: flex-start;
+  }
 }
 
 @media (min-width: 800px) {

--- a/tenant.html
+++ b/tenant.html
@@ -34,87 +34,69 @@
   <div id="notificationTray" class="notification-tray"></div>
   <h1>r3nt View Pass</h1>
 
-  <section class="card" data-collapsible>
-    <button type="button" class="inline-button collapsible-toggle" data-collapsible-toggle>
-      Wallet connection
-    </button>
-    <div data-collapsible-content hidden>
-      <p class="muted">Connect your wallet to unlock bookings and manage your stays.</p>
+  <section class="card">
+    <h2>Wallet &amp; View Pass</h2>
+    <p class="muted">Connect your wallet to unlock bookings, manage stays and keep your View Pass active.</p>
+    <div class="card-actions">
       <button id="connect">Connect Wallet</button>
-      <div id="address">Not connected</div>
-      <div id="status">Loading…</div>
-    </div>
-  </section>
-
-  <section class="card" data-collapsible>
-    <button type="button" class="inline-button collapsible-toggle" data-collapsible-toggle>
-      View pass access
-    </button>
-    <div data-collapsible-content>
-      <p class="muted">Purchase or renew your View Pass before confirming a booking.</p>
       <button id="buy" disabled>Buy View Pass</button>
     </div>
+    <div id="address">Not connected</div>
+    <div id="status">Waiting for wallet connection.</div>
   </section>
 
-  <section class="card" data-collapsible>
-    <button type="button" class="inline-button collapsible-toggle" data-collapsible-toggle>
-      Plan your stay
-    </button>
-    <div data-collapsible-content>
-      <p>Choose dates and how often you'd like to pay to preview totals before booking.</p>
-      <div class="planner-grid">
-        <div class="planner-inputs">
-          <label>Check-in
-            <input type="date" id="startDate">
-          </label>
-          <label>Check-out
-            <input type="date" id="endDate">
-          </label>
-          <label>How often you'll pay rent
-            <select id="paymentPeriod">
-              <option value="">Select how often…</option>
-              <option value="day">Daily</option>
-              <option value="week">Weekly</option>
-              <option value="month">Monthly</option>
-            </select>
-          </label>
-        </div>
-        <div class="planner-summary" id="bookingSummary">
-          <div class="summary-header">
-            <div class="summary-title" data-summary-title>No listing selected</div>
-            <div class="summary-subtitle" data-summary-subtitle>Select a property to preview totals.</div>
+  <section id="bookingsSection" class="card">
+    <h2>Your bookings</h2>
+    <p class="muted">Active and past stays linked to your connected wallet.</p>
+    <div class="bookings-status" data-bookings-status>Connect wallet to view bookings.</div>
+    <div id="bookingsList" class="bookings-list"></div>
+    <div id="tokenProposalPanel" class="token-proposal-card" hidden></div>
+  </section>
+
+  <section class="card planner-card" data-planner-card>
+    <h2>Plan your stay</h2>
+    <p class="muted">Explore listings and configure your stay details. The booking form appears when you choose a property.</p>
+    <div class="planner-layout">
+      <div class="planner-form" data-planner-form hidden>
+        <div class="planner-grid">
+          <div class="planner-inputs">
+            <label>Check-in
+              <input type="date" id="startDate">
+            </label>
+            <label>Check-out
+              <input type="date" id="endDate">
+            </label>
+            <label>How often you'll pay rent
+              <select id="paymentPeriod">
+                <option value="">Select how often…</option>
+                <option value="day">Daily</option>
+                <option value="week">Weekly</option>
+                <option value="month">Monthly</option>
+              </select>
+            </label>
           </div>
-          <dl class="summary-breakdown">
-            <div><dt>Stay length</dt><dd data-summary-nights>—</dd></div>
-            <div><dt>Deposit <span class="info-dot" title="Deposits are escrowed on-chain and require landlord and platform approval before release.">?</span></dt><dd data-summary-deposit>—</dd></div>
-            <div><dt>Total rent</dt><dd data-summary-rent>—</dd></div>
-            <div><dt>Installments</dt><dd data-summary-installment>—</dd></div>
-            <div><dt>Due today</dt><dd data-summary-total>—</dd></div>
-          </dl>
-          <button id="confirmBooking" disabled>Confirm booking</button>
-          <div class="summary-footnote" data-summary-notice>Select stay dates to continue.</div>
+          <div class="planner-summary" id="bookingSummary">
+            <div class="summary-header">
+              <div class="summary-title" data-summary-title>No listing selected</div>
+              <div class="summary-subtitle" data-summary-subtitle>Select a property to preview totals.</div>
+            </div>
+            <dl class="summary-breakdown">
+              <div><dt>Stay length</dt><dd data-summary-nights>—</dd></div>
+              <div><dt>Deposit <span class="info-dot" title="Deposits are escrowed on-chain and require landlord and platform approval before release.">?</span></dt><dd data-summary-deposit>—</dd></div>
+              <div><dt>Total rent</dt><dd data-summary-rent>—</dd></div>
+              <div><dt>Installments</dt><dd data-summary-installment>—</dd></div>
+              <div><dt>Due today</dt><dd data-summary-total>—</dd></div>
+            </dl>
+            <button id="confirmBooking" disabled>Confirm booking</button>
+            <div class="summary-footnote" data-summary-notice>Select stay dates to continue.</div>
+          </div>
         </div>
       </div>
-    </div>
-  </section>
-
-  <section id="bookingsSection" class="card" data-collapsible>
-    <button type="button" class="inline-button collapsible-toggle" data-collapsible-toggle>
-      Your bookings
-    </button>
-    <div data-collapsible-content>
-      <div class="bookings-status" data-bookings-status>Connect wallet to view bookings.</div>
-      <div id="bookingsList" class="bookings-list"></div>
-      <div id="tokenProposalPanel" class="token-proposal-card" hidden></div>
-    </div>
-  </section>
-
-  <section class="card" data-collapsible>
-    <button type="button" class="inline-button collapsible-toggle" data-collapsible-toggle>
-      Browse listings
-    </button>
-    <div data-collapsible-content>
-      <div id="listings"></div>
+      <div class="planner-listings">
+        <h3>Available listings</h3>
+        <p class="muted" data-planner-empty>Select a listing to open the booking form.</p>
+        <div id="listings"></div>
+      </div>
     </div>
   </section>
   <footer>


### PR DESCRIPTION
## Summary
- redesign the tenant page to use card-based sections, combining wallet/view pass controls and embedding available listings alongside the planning form
- update tenant interactions to reveal the booking form when "Book" is clicked, focus date inputs, adjust listing actions, and limit tokenisation proposals to active bookings
- add styling for the new planner layout and active state to keep the UI aligned with the investor dashboard polish

## Testing
- Not run (frontend changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d50902dfa4832a82b8984c943a9e43