### PR TITLE
Default landlord panels closed and remove duplicate listing actions

### DIFF
--- a/js/landlord.js
+++ b/js/landlord.js
@@ -5,7 +5,6 @@ import { assertLatLon, geohashToLatLon, latLonToGeohash, isHex20or32, toBytes32F
 import { requestWalletSendCalls, isUserRejectedRequestError } from './wallet.js';
 import { notify, mountNotificationCenter } from './notifications.js';
 import { ListingCard, BookingCard, TokenisationCard } from './ui/cards.js';
-import { actionsFor } from './ui/actions.js';
 import { createCollapsibleSection, mountCollapsibles } from './ui/accordion.js';
 import { el, fmt } from './ui/dom.js';
 import {
@@ -1083,21 +1082,6 @@ function renderLandlordListingCard(listing) {
     Number.isFinite(listing?.lat) && Number.isFinite(listing?.lon)
       ? `${Number(listing.lat).toFixed(5)}, ${Number(listing.lon).toFixed(5)}`
       : '—';
-  let focusAvailabilitySection = () => {};
-  let openTokenSection = () => {};
-
-  const actions = actionsFor({
-    role: 'landlord',
-    entity: 'listing',
-    perms: {
-      onCheck: () => focusAvailabilitySection(),
-      onToggleActive: () => handleDeactivateListing(listing),
-      active: listing?.active !== false,
-      onPropose: () => openTokenSection(),
-      canPropose: true,
-    },
-  });
-
   const card = ListingCard({
     id: listingIdText || shortAddress(listing?.address || '') || `listing-${listing?.order ?? 0}`,
     title: listing?.title,
@@ -1106,7 +1090,6 @@ function renderLandlordListingCard(listing) {
     areaSqm: areaValue > 0 ? areaValue : undefined,
     depositUSDC: listing.depositAmount,
     status: listing?.active === false ? 'Inactive' : 'Active',
-    actions,
   });
 
   card.classList.add('landlord-listing-card');
@@ -1240,13 +1223,6 @@ function renderLandlordListingCard(listing) {
   availabilityPanel.content.append(dateRow, checkBtn, result);
   sections.append(availabilityPanel.section);
 
-  focusAvailabilitySection = () => {
-    availabilityPanel.setOpen(true);
-    try {
-      availabilityPanel.section.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    } catch {}
-  };
-
   checkBtn.onclick = () =>
     disableWhile(checkBtn, async () => {
       try {
@@ -1289,7 +1265,6 @@ function renderLandlordListingCard(listing) {
 
   const tokenTools = createTokenTools(listing);
   sections.append(tokenTools.section);
-  openTokenSection = () => tokenTools.controller.openPanel({ focus: true });
 
   const controller = {
     listing,

--- a/js/ui/cards.js
+++ b/js/ui/cards.js
@@ -13,7 +13,10 @@ const periodLabel = (value) => {
 };
 
 export function ListingCard({ id, title, location, pricePerDayUSDC, areaSqm, depositUSDC, status, actions = [] }) {
-  return el('div', { class: 'card listing-card', dataset: { id } }, [
+  const visibleActions = actions.filter((a) => a?.visible !== false);
+  const actionButtons = visibleActions.map((a) => el('button', { class: 'inline-button', onClick: a.onClick }, a.label));
+
+  const children = [
     el('div', { class: 'card-header' }, [
       el('strong', {}, title || `Listing #${id}`),
       el('div', { class: 'card-meta' }, [
@@ -24,14 +27,13 @@ export function ListingCard({ id, title, location, pricePerDayUSDC, areaSqm, dep
         status ? Pill(status) : null,
       ].filter(Boolean)),
     ]),
-    el(
-      'div',
-      { class: 'card-actions' },
-      actions
-        .filter((a) => a?.visible !== false)
-        .map((a) => el('button', { class: 'inline-button', onClick: a.onClick }, a.label)),
-    ),
-  ]);
+  ];
+
+  if (actionButtons.length > 0) {
+    children.push(el('div', { class: 'card-actions' }, actionButtons));
+  }
+
+  return el('div', { class: 'card listing-card', dataset: { id } }, children);
 }
 
 export function BookingCard({

--- a/landlord.html
+++ b/landlord.html
@@ -59,7 +59,7 @@
 
   <!-- Removed manual Cast URL/Hash field. We will compose and capture the hash automatically. -->
 
-  <section class="card" data-collapsible data-open="1">
+  <section class="card" data-collapsible>
     <button type="button" class="inline-button collapsible-toggle" data-collapsible-toggle>
       Configure new listing
     </button>
@@ -188,7 +188,7 @@
     </div>
   </section>
 
-  <section class="card" data-collapsible data-open="1">
+  <section class="card" data-collapsible>
     <button type="button" class="inline-button collapsible-toggle" data-collapsible-toggle>
       Manage existing listings
     </button>


### PR DESCRIPTION
## Summary
- start landlord page accordions closed by default so the create and manage sections stay collapsed on load
- remove redundant quick action buttons from the landlord listing header to rely on the detailed panels
- hide the empty action row in listing cards when no actions are supplied

## Testing
- not run (frontend-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d5b0ab17c4832a98a87adc0ff2d260