### PR TITLE
Improve landlord listing summaries and collapsible cards

### DIFF
--- a/landlord.html
+++ b/landlord.html
@@ -47,6 +47,7 @@
   </nav>
   <div id="notificationTray" class="notification-tray"></div>
   <h1>r3nt — Create Listing</h1>
+  <p class="lead">Launch new properties, preview platform fees and keep existing listings in sync with Farcaster.</p>
 
   <section class="card">
     <h2>Wallet &amp; platform setup</h2>
@@ -63,8 +64,9 @@
     <button type="button" class="inline-button collapsible-toggle" data-collapsible-toggle>
       Configure new listing
     </button>
+    <p class="muted section-summary">Step through the checklist to prepare property metadata, pricing and booking preferences.</p>
     <div data-collapsible-content>
-      <p class="muted">Follow the guided sections to publish a new property. Each step helps us generate on-chain metadata and your Farcaster cast.</p>
+      <p class="muted">Complete each guided section to capture the details required for your on-chain listing and Farcaster cast.</p>
       <div class="guided-section">
         <h3>1. Property basics</h3>
         <p class="section-subtext">We use these details to generate your Farcaster cast and metadata.</p>
@@ -192,8 +194,9 @@
     <button type="button" class="inline-button collapsible-toggle" data-collapsible-toggle>
       Manage existing listings
     </button>
+    <p class="muted section-summary">Review live properties, inspect bookings and access deposit or tokenisation tools.</p>
     <div data-collapsible-content>
-      <p class="muted">Access live availability tools and filters for every property linked to your wallet.</p>
+      <p class="muted">Use the filters and quick actions below to explore availability, manage deposits and handle tokenised stays.</p>
       <div id="listingControls" class="listing-controls" hidden>
         <label>
           <span>Sort by</span>


### PR DESCRIPTION
## Summary
- add page lead and section descriptions to the landlord dashboard
- render landlord listing entries as collapsible cards that are closed by default
- open the appropriate listing panel when quick actions jump into token tools

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d5b326c3a0832aa2c4dabd203b73dd