### PR TITLE
Remove tokenisation proposal action from tenant listings

### DIFF
--- a/js/ui/actions.js
+++ b/js/ui/actions.js
@@ -15,7 +15,6 @@ export function actionsFor({ role, entity, perms }) {
       },
       { label:'Check availability', onClick: perms.onCheck, visible: role==='landlord' },
       { label: perms.active ? 'Deactivate' : 'Activate', onClick: perms.onToggleActive, visible: role==='landlord' },
-      { label:'Propose tokenisation', onClick: perms.onPropose, visible: perms.canPropose },
     ];
   }
   if (entity === 'booking') {


### PR DESCRIPTION
## Summary
- remove the propose tokenisation action from listing cards in the tenant "Plan your stay" view to ensure tokenisation is only initiated from active bookings

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5b73bfd54832ab7deb6a5480686e2