### PR TITLE
Display listing summaries in tenant planner

### DIFF
--- a/js/tenant.js
+++ b/js/tenant.js
@@ -516,6 +516,27 @@ function getListingTitle(info) {
   return 'Listing';
 }
 
+function getListingShortDescription(info) {
+  if (!info) return '';
+  const candidates = [];
+  if (typeof info.shortDescription === 'string') {
+    candidates.push(info.shortDescription);
+  }
+  if (typeof info.description === 'string') {
+    candidates.push(info.description);
+  }
+  const title = getListingTitle(info);
+  for (const candidate of candidates) {
+    const trimmed = (candidate || '').trim();
+    if (!trimmed) continue;
+    if (trimmed === title) continue;
+    if (typeof info.displayTitle === 'string' && trimmed === info.displayTitle.trim()) continue;
+    if (typeof info.address === 'string' && trimmed === info.address.trim()) continue;
+    return trimmed;
+  }
+  return '';
+}
+
 function getListingSubtitle(info) {
   if (!info) {
     return 'Select a property to preview totals.';
@@ -1071,6 +1092,7 @@ function renderListings(listings, options = {}) {
     const card = ListingCard({
       id: record.id,
       title: record.displayTitle || record.title || getListingTitle(record),
+      summary: getListingShortDescription(record),
       location: record.locationPill || getListingLocationPill(record),
       pricePerDayUSDC: record.baseDailyRate,
       areaSqm: Number.isFinite(record.areaSqm) ? record.areaSqm : undefined,
@@ -1080,13 +1102,6 @@ function renderListings(listings, options = {}) {
     });
     card.dataset.address = record.address || '';
     card.dataset.displayTitle = record.displayTitle || '';
-
-    if (record && typeof record.description === 'string') {
-      const trimmed = record.description.trim();
-      if (trimmed && trimmed !== record.displayTitle && trimmed !== record.address) {
-        card.append(el('div', { class: 'card-footnote listing-summary' }, trimmed));
-      }
-    }
 
     const minNoticeText = fmt.duration(record.minBookingNotice);
     const maxWindowText = record.maxBookingWindow > 0n ? fmt.duration(record.maxBookingWindow) : 'Unlimited';

--- a/js/ui/cards.js
+++ b/js/ui/cards.js
@@ -12,22 +12,38 @@ const periodLabel = (value) => {
   return typeof value === 'string' ? value : String(value);
 };
 
-export function ListingCard({ id, title, location, pricePerDayUSDC, areaSqm, depositUSDC, status, actions = [] }) {
+export function ListingCard({
+  id,
+  title,
+  summary,
+  location,
+  pricePerDayUSDC,
+  areaSqm,
+  depositUSDC,
+  status,
+  actions = [],
+}) {
   const visibleActions = actions.filter((a) => a?.visible !== false);
   const actionButtons = visibleActions.map((a) => el('button', { class: 'inline-button', onClick: a.onClick }, a.label));
+  const summaryText = typeof summary === 'string' ? summary.trim() : '';
 
-  const children = [
-    el('div', { class: 'card-header' }, [
-      el('strong', {}, title || `Listing #${id}`),
-      el('div', { class: 'card-meta' }, [
-        Pill(location || '—'),
-        pricePerDayUSDC != null ? Pill(`Daily ${fmt.usdc(pricePerDayUSDC)} USDC`) : null,
-        areaSqm != null ? Pill(fmt.sqm(areaSqm)) : null,
-        depositUSDC != null ? Pill(`Deposit ${fmt.usdc(depositUSDC)} USDC`) : null,
-        status ? Pill(status) : null,
-      ].filter(Boolean)),
-    ]),
-  ];
+  const headerChildren = [el('strong', {}, title || `Listing #${id}`)];
+  if (summaryText) {
+    headerChildren.push(el('div', { class: 'listing-summary' }, summaryText));
+  }
+
+  const metaPills = [
+    Pill(location || '—'),
+    pricePerDayUSDC != null ? Pill(`Daily ${fmt.usdc(pricePerDayUSDC)} USDC`) : null,
+    areaSqm != null ? Pill(fmt.sqm(areaSqm)) : null,
+    depositUSDC != null ? Pill(`Deposit ${fmt.usdc(depositUSDC)} USDC`) : null,
+    status ? Pill(status) : null,
+  ].filter(Boolean);
+  if (metaPills.length > 0) {
+    headerChildren.push(el('div', { class: 'card-meta' }, metaPills));
+  }
+
+  const children = [el('div', { class: 'card-header' }, headerChildren)];
 
   if (actionButtons.length > 0) {
     children.push(el('div', { class: 'card-actions' }, actionButtons));


### PR DESCRIPTION
## Summary
- update tenant listing cards to surface each listing's short description directly beneath the title
- extend the shared ListingCard UI helper to support optional summaries ahead of the meta pill list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c4a40b20832aa477542f3b86bdbb