### PR TITLE
Use geo URI for tenant map link

### DIFF
--- a/js/tenant.js
+++ b/js/tenant.js
@@ -1130,12 +1130,15 @@ function renderListings(listings, options = {}) {
         }
         geoLine.append(copyBtn);
         geoLine.append(
-          el('a', {
-            href: `https://www.google.com/maps/search/?api=1&query=${preciseCoords}`,
-            target: '_blank',
-            rel: 'noopener',
-            class: 'geo-map-link',
-          }, 'Open map'),
+          el(
+            'a',
+            {
+              href: `geo:${preciseCoords}`,
+              class: 'geo-map-link',
+              title: 'Open in your preferred maps app',
+            },
+            'Open map',
+          ),
         );
       }
       card.append(geoLine);


### PR DESCRIPTION
## Summary
- replace the Google Maps search URL in tenant listing cards with a standards-based geo: URI so the device chooses the map app
- add a tooltip clarifying that the link opens in the visitor's preferred maps app

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6d4c8c754832aa311a897ed8c70cb