### PR TITLE
Add reusable map buttons for listing coordinates

### DIFF
--- a/js/map-assist.js
+++ b/js/map-assist.js
@@ -16,6 +16,18 @@ export function detectPlatform(userAgent = (typeof navigator !== "undefined" ? n
   return "other";
 }
 
+function normaliseCoords(value) {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const lat = Number(value.lat ?? value.latitude);
+  const lon = Number(value.lon ?? value.lng ?? value.longitude);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return null;
+  }
+  return { lat, lon };
+}
+
 /**
  * Build the best mapping URL for the active platform.
  * @param {number} lat
@@ -75,7 +87,15 @@ export function openMapsAt(lat, lon, options = {}) {
 /**
  * Attach a click handler to a button (or any EventTarget) that triggers map navigation.
  * @param {Element|EventTarget|null} target
- * @param {{ fallbackCoords?: { lat: number, lon: number }, highAccuracy?: boolean, timeoutMs?: number, platform?: "ios"|"android"|"other" }} [options]
+ * @param {{
+ *   coords?: { lat: number, lon: number } | null,
+ *   resolveCoords?: () => ({ lat: number, lon: number } | null | undefined),
+ *   fallbackCoords?: { lat: number, lon: number },
+ *   highAccuracy?: boolean,
+ *   timeoutMs?: number,
+ *   platform?: "ios"|"android"|"other",
+ *   onError?: (err: unknown) => void,
+ * }} [options]
  */
 export function attachNavigateHandler(target, options = {}) {
   if (!target || typeof target.addEventListener !== "function") {
@@ -83,18 +103,78 @@ export function attachNavigateHandler(target, options = {}) {
   }
 
   const {
+    coords,
+    resolveCoords,
     fallbackCoords = DEFAULT_FALLBACK_COORDS,
     highAccuracy = true,
     timeoutMs = 8000,
     platform,
+    onError,
   } = options;
 
   const invoke = (lat, lon) => openMapsAt(lat, lon, { platform });
 
+  const fallback = normaliseCoords(fallbackCoords) || DEFAULT_FALLBACK_COORDS;
+
+  const normaliseDirectCoords = () => {
+    if (typeof resolveCoords === "function") {
+      try {
+        const resolved = resolveCoords();
+        const normalised = normaliseCoords(resolved);
+        if (normalised) {
+          return normalised;
+        }
+      } catch (err) {
+        if (typeof onError === "function") {
+          onError(err);
+        } else {
+          console.error("Failed to resolve coordinates for map navigation", err);
+        }
+      }
+    }
+
+    const provided = normaliseCoords(coords);
+    if (provided) {
+      return provided;
+    }
+
+    const dataset = normaliseCoords(target?.dataset);
+    if (dataset) {
+      return dataset;
+    }
+
+    return null;
+  };
+
+  const handleError = (err) => {
+    if (typeof onError === "function") {
+      try {
+        onError(err);
+      } catch (notifyErr) {
+        console.error("Error handler for map navigation threw", notifyErr);
+      }
+    } else {
+      console.error("Map navigation failed", err);
+    }
+  };
+
+  const safeInvoke = (lat, lon) => {
+    try {
+      invoke(lat, lon);
+    } catch (err) {
+      handleError(err);
+    }
+  };
+
   const handleClick = () => {
-    const coords = fallbackCoords || DEFAULT_FALLBACK_COORDS;
+    const targetCoords = normaliseDirectCoords();
+    if (targetCoords) {
+      safeInvoke(targetCoords.lat, targetCoords.lon);
+      return;
+    }
+
     if (typeof navigator === "undefined" || !navigator.geolocation) {
-      invoke(coords.lat, coords.lon);
+      safeInvoke(fallback.lat, fallback.lon);
       return;
     }
 
@@ -102,18 +182,55 @@ export function attachNavigateHandler(target, options = {}) {
       (pos) => {
         const { latitude, longitude } = pos.coords || {};
         if (Number.isFinite(latitude) && Number.isFinite(longitude)) {
-          invoke(latitude, longitude);
+          safeInvoke(Number(latitude), Number(longitude));
         } else {
-          invoke(coords.lat, coords.lon);
+          safeInvoke(fallback.lat, fallback.lon);
         }
       },
-      () => invoke(coords.lat, coords.lon),
+      (err) => {
+        handleError(err);
+        safeInvoke(fallback.lat, fallback.lon);
+      },
       { enableHighAccuracy: highAccuracy, timeout: timeoutMs }
     );
   };
 
   target.addEventListener("click", handleClick);
   return () => target.removeEventListener("click", handleClick);
+}
+
+export function createOpenMapButton({
+  lat,
+  lon,
+  label = "Open in Map",
+  className = "inline-button",
+  disabledTitle = "Coordinates unavailable",
+  platform,
+  onError,
+} = {}) {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = label;
+  if (className) {
+    button.className = className;
+  }
+
+  const coords = normaliseCoords({ lat, lon });
+  if (coords) {
+    button.dataset.lat = String(coords.lat);
+    button.dataset.lon = String(coords.lon);
+    attachNavigateHandler(button, { platform, onError });
+  } else {
+    button.disabled = true;
+    if (disabledTitle) {
+      button.title = disabledTitle;
+    }
+  }
+
+  return button;
 }
 
 export { DEFAULT_FALLBACK_COORDS };

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -718,14 +718,12 @@ footer {
   flex-wrap: wrap;
 }
 
-.listing-link,
-.geo-map-link {
+.listing-link {
   color: var(--color-link);
   font-weight: 600;
 }
 
-.listing-link:hover,
-.geo-map-link:hover {
+.listing-link:hover {
   text-decoration: underline;
 }
 
@@ -1016,6 +1014,24 @@ footer {
   font-size: 0.9rem;
   margin: 0;
   color: var(--color-muted-strong);
+}
+
+.landlord-card-coords {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.landlord-card-coords-label {
+  flex: 1 1 auto;
+  min-width: 180px;
+}
+
+.landlord-card-coords-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .landlord-card-address,
@@ -1485,6 +1501,10 @@ dl.summary-breakdown dd {
   align-items: center;
   color: var(--color-muted);
   font-size: 0.85rem;
+}
+
+.geo-map-button {
+  white-space: nowrap;
 }
 
 .listing-actions {


### PR DESCRIPTION
## Summary
- refactor the map assistant to normalise coordinates and provide a reusable "Open in Map" button helper
- replace the tenant listing map link with the new button alongside clipboard support and error handling
- add the same coordinate copy and map controls to landlord listing cards with matching styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6db38e49c832a85779900ca899d13