### PR TITLE
Remove remnant listing pill from tenant booking cards

### DIFF
--- a/js/tenant.js
+++ b/js/tenant.js
@@ -1825,7 +1825,6 @@ function renderBookings(records, emptyMessage = 'No bookings found for this wall
     if (record.statusClass) {
       card.classList.add(`booking-status-${record.statusClass}`);
     }
-    card.append(el('div', { class: 'card-footnote' }, record.listingTitle));
     const rentFootnote = record.rentDue > 0n
       ? `Outstanding rent: ${fmt.usdc(record.rentDue)} USDC`
       : 'All rent settled.';


### PR DESCRIPTION
## Summary
- remove the unused listing title footnote from tenant booking cards so the stray pill no longer renders

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68d6ff956df8832a9b07517f7ce83815