### PR TITLE
Fix map link opening to avoid popup blocking

### DIFF
--- a/js/map-assist.js
+++ b/js/map-assist.js
@@ -44,9 +44,10 @@ export function createOpenMapButton(options = {}) {
   );
 
   mapLink.addEventListener('click', (event) => {
-    event.preventDefault();
-    const win = window.open(href, '_blank', 'noopener');
+    const win = window.open(href, '_blank', 'noopener,noreferrer');
     if (win) {
+      win.opener = null;
+      event.preventDefault();
       try {
         win.focus();
       } catch (_) {


### PR DESCRIPTION
## Summary
- adjust the map link click handler to open the Google Maps tab before cancelling the default navigation
- clear the opener handle and request noreferrer to preserve the security posture when the popup succeeds

## Testing
- not run (frontend change)

------
https://chatgpt.com/codex/tasks/task_e_68d70e8d3d30832ab03d354105f8daf0