### PR TITLE
Avoid treating popup block as map error

### DIFF
--- a/js/map-assist.js
+++ b/js/map-assist.js
@@ -44,20 +44,21 @@ export function createOpenMapButton(options = {}) {
   );
 
   mapLink.addEventListener('click', (event) => {
-    const win = window.open(href, '_blank', 'noopener,noreferrer');
-    if (win) {
-      win.opener = null;
-      event.preventDefault();
-      try {
-        win.focus();
-      } catch (_) {
-        // ignore focus errors
+    try {
+      const win = window.open(href, '_blank', 'noopener,noreferrer');
+      if (win) {
+        win.opener = null;
+        event.preventDefault();
+        try {
+          win.focus();
+        } catch (_) {
+          // ignore focus errors
+        }
       }
-      return;
-    }
-
-    if (typeof onError === 'function') {
-      onError(new Error('Map window was blocked.'));
+    } catch (err) {
+      if (typeof onError === 'function') {
+        onError(err);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- stop logging an error when browsers block the programmatic map popup
- keep focusing behaviour when the popup is successfully opened

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7117801d0832a93ce44473bbded5a