### PR TITLE
Align geo copy button dimensions with map button

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1503,7 +1503,8 @@ dl.summary-breakdown dd {
   font-size: 0.85rem;
 }
 
-.geo-map-button {
+.geo-map-button,
+.geo-copy-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1512,7 +1513,8 @@ dl.summary-breakdown dd {
   text-decoration: none;
 }
 
-.geo-map-button:hover {
+.geo-map-button:hover,
+.geo-copy-button:hover {
   text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary
- update the geo copy button styling to match the map button layout
- ensure both buttons share inline-flex alignment for consistent dimensions and spacing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7163e995c832ab40be3fa2063a8c8