### PR TITLE
Fix duplicate map openings

### DIFF
--- a/js/map-assist.js
+++ b/js/map-assist.js
@@ -47,8 +47,8 @@ export function createOpenMapButton(options = {}) {
     try {
       const win = window.open(href, '_blank', 'noopener,noreferrer');
       if (win) {
-        win.opener = null;
         event.preventDefault();
+        win.opener = null;
         try {
           win.focus();
         } catch (_) {


### PR DESCRIPTION
## Summary
- prevent the Open in Map button from triggering both window.open and the default link navigation when a new tab is created

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d718cf6a44832aa6ac8210e9ec8ae2