### PR TITLE
Ensure map button opens link once

### DIFF
--- a/js/map-assist.js
+++ b/js/map-assist.js
@@ -44,17 +44,23 @@ export function createOpenMapButton(options = {}) {
   );
 
   mapLink.addEventListener('click', (event) => {
+    event.preventDefault();
+
     try {
       const win = window.open(href, '_blank', 'noopener,noreferrer');
       if (win) {
-        event.preventDefault();
         win.opener = null;
         try {
           win.focus();
         } catch (_) {
           // ignore focus errors
         }
+        return;
       }
+
+      // Popup blockers may prevent window.open from succeeding; fall back to
+      // navigating in the current tab so the user still reaches the map.
+      window.location.assign(href);
     } catch (err) {
       if (typeof onError === 'function') {
         onError(err);


### PR DESCRIPTION
## Summary
- prevent the map button click handler from allowing the browser to follow the anchor and the scripted window.open simultaneously
- fall back to navigating in the current tab when window.open is blocked so the user still reaches the map

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d72b0345f0832abe10264696886a3a