### PR TITLE
Adjust map button popup behavior

### DIFF
--- a/js/map-assist.js
+++ b/js/map-assist.js
@@ -44,27 +44,27 @@ export function createOpenMapButton(options = {}) {
   );
 
   mapLink.addEventListener('click', (event) => {
-    event.preventDefault();
-
+    let win;
     try {
-      const win = window.open(href, '_blank', 'noopener,noreferrer');
-      if (win) {
-        win.opener = null;
-        try {
-          win.focus();
-        } catch (_) {
-          // ignore focus errors
-        }
-        return;
-      }
-
-      // Popup blockers may prevent window.open from succeeding; fall back to
-      // navigating in the current tab so the user still reaches the map.
-      window.location.assign(href);
+      win = window.open(href, '_blank', 'noopener,noreferrer');
     } catch (err) {
       if (typeof onError === 'function') {
         onError(err);
       }
+      return;
+    }
+
+    if (!win) {
+      return;
+    }
+
+    event.preventDefault();
+
+    win.opener = null;
+    try {
+      win.focus();
+    } catch (_) {
+      // ignore focus errors
     }
   });
 


### PR DESCRIPTION
## Summary
- ensure the map button only cancels navigation when `window.open` successfully returns a handle
- remove the `window.location.assign` fallback so the anchor's default `_blank` behavior handles popup failures

## Testing
- Manual testing: not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d731667170832a8e831a2ca9b3f179