### PR TITLE
Use Farcaster mini-app openUrl helper for map links

### DIFF
--- a/js/map-assist.js
+++ b/js/map-assist.js
@@ -1,3 +1,4 @@
+import { sdk } from 'https://esm.sh/@farcaster/miniapp-sdk';
 import { el } from './ui/dom.js';
 
 const GOOGLE_MAPS_SEARCH_URL = 'https://www.google.com/maps/search/?api=1';
@@ -43,7 +44,21 @@ export function createOpenMapButton(options = {}) {
     label,
   );
 
-  mapLink.addEventListener('click', (event) => {
+  mapLink.addEventListener('click', async (event) => {
+    event.preventDefault();
+
+    if (sdk?.actions?.openUrl) {
+      try {
+        await sdk.actions.openUrl(href);
+        return;
+      } catch (err) {
+        if (typeof onError === 'function') {
+          onError(err);
+        }
+        // fall through to window.open fallback
+      }
+    }
+
     let win;
     try {
       win = window.open(href, '_blank', 'noopener,noreferrer');
@@ -57,8 +72,6 @@ export function createOpenMapButton(options = {}) {
     if (!win) {
       return;
     }
-
-    event.preventDefault();
 
     win.opener = null;
     try {


### PR DESCRIPTION
## Summary
- use the Farcaster mini-app SDK in the map helper so map links call `sdk.actions.openUrl`
- keep the existing window fallback while preventing duplicate navigation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d73da606f0832a97710df27ca131ac