### PR TITLE
Use miniapp openUrl for map navigation

### DIFF
--- a/js/map-assist.js
+++ b/js/map-assist.js
@@ -47,37 +47,19 @@ export function createOpenMapButton(options = {}) {
   mapLink.addEventListener('click', async (event) => {
     event.preventDefault();
 
-    if (sdk?.actions?.openUrl) {
-      try {
-        await sdk.actions.openUrl(href);
-        return;
-      } catch (err) {
-        if (typeof onError === 'function') {
-          onError(err);
-        }
-        // fall through to window.open fallback
+    if (!sdk?.actions?.openUrl) {
+      if (typeof onError === 'function') {
+        onError(new Error('Mini app SDK openUrl action is unavailable'));
       }
+      return;
     }
 
-    let win;
     try {
-      win = window.open(href, '_blank', 'noopener,noreferrer');
+      await sdk.actions.openUrl(href);
     } catch (err) {
       if (typeof onError === 'function') {
         onError(err);
       }
-      return;
-    }
-
-    if (!win) {
-      return;
-    }
-
-    win.opener = null;
-    try {
-      win.focus();
-    } catch (_) {
-      // ignore focus errors
     }
   });
 


### PR DESCRIPTION
## Summary
- update the map helper to rely on the Mini App SDK `openUrl` action for navigation
- surface an error through the provided callback when `openUrl` is unavailable or fails

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d73ee66fdc832ab1ae423ad53d0a1a