### PR TITLE
Enable landlord bookings refresh button by default

### DIFF
--- a/js/landlord.js
+++ b/js/landlord.js
@@ -1404,7 +1404,6 @@ function renderLandlordListingCard(listing) {
   const bookingsRefresh = el('button', {
     type: 'button',
     class: 'inline-button small',
-    disabled: true,
   }, 'Refresh');
   const bookingsStatus = el('div', { class: 'bookings-status' }, 'Press refresh to load bookings.');
   const bookingsList = el('div', { class: 'bookings-list' });


### PR DESCRIPTION
## Summary
- allow the landlord bookings refresh control to be clickable immediately while keeping the loading-state toggles intact

## Testing
- Manual verification via local browser session

------
https://chatgpt.com/codex/tasks/task_e_68d749926030832aaaee9149fb8f5df8