### PR TITLE
Add helper to assert listing ownership on landlord actions

### DIFF
--- a/js/landlord.js
+++ b/js/landlord.js
@@ -79,6 +79,31 @@ function addressesEqual(a, b) {
   return normaliseAddress(a) === normaliseAddress(b);
 }
 
+async function assertListingOwnership(listingAddress, account) {
+  if (!listingAddress) {
+    throw new Error('Listing address is required to verify ownership.');
+  }
+  if (!account) {
+    throw new Error('Connect your wallet to continue.');
+  }
+
+  let landlord;
+  try {
+    landlord = await pub.readContract({
+      address: listingAddress,
+      abi: LISTING_ABI,
+      functionName: 'landlord',
+    });
+  } catch (err) {
+    console.error('Failed to verify listing ownership', err);
+    throw new Error('Unable to verify listing ownership. Please try again.');
+  }
+
+  if (!addressesEqual(landlord, account)) {
+    throw new Error('Connected wallet does not match the listing landlord.');
+  }
+}
+
 function isUnknownBookingError(err) {
   if (!err) return false;
 


### PR DESCRIPTION
## Summary
- add an `assertListingOwnership` helper for landlord flows
- reuse the shared public client and listing ABI to read the landlord address
- throw descriptive errors when the connected wallet does not own the listing

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d750a28b5c832a8224cf0265183be2