### PR TITLE
Prevent tenant cancellation of tokenised bookings

### DIFF
--- a/js/tenant.js
+++ b/js/tenant.js
@@ -1251,6 +1251,10 @@ function buildBookingRecord(meta, data, pending, listingInfo) {
   const expectedNetRent = toBigInt(data.expectedNetRent, 0n);
   const depositReleased = Boolean(data.depositReleased);
   const tokenised = Boolean(data.tokenised);
+  const hasApprovedTokenisation =
+    tokenised ||
+    soldSqmu > 0n ||
+    (totalSqmu > 0n && pricePerSqmu > 0n);
   const pendingInfoRaw = pending ? normaliseTokenisationView(pending) : null;
   const pendingExists = Boolean(pendingInfoRaw?.exists);
   const pendingTotalSqmu = toBigInt(pendingInfoRaw?.totalSqmu, 0n);
@@ -1271,6 +1275,8 @@ function buildBookingRecord(meta, data, pending, listingInfo) {
   let cancelDisabledReason = '';
   if (!isActive) {
     cancelDisabledReason = 'Only active bookings can be cancelled.';
+  } else if (hasApprovedTokenisation) {
+    cancelDisabledReason = 'Tokenised bookings cannot be cancelled while SQMU-R fundraising is live.';
   } else if (!isUpcoming) {
     cancelDisabledReason = 'Cancellation is unavailable once the stay has started.';
   } else if (depositReleased) {


### PR DESCRIPTION
## Summary
- prevent the tenant booking builder from enabling cancellation after SQMU tokenisation approval
- surface a clear footnote explaining why cancellation is disabled when fundraising is live

## Testing
- Manual verification in tenant dashboard via Playwright simulation

------
https://chatgpt.com/codex/tasks/task_e_68d7719c1244832aa75ae311ce52cab2