### PR TITLE
Prevent cancellation of tokenised bookings

### DIFF
--- a/contracts/Listing.sol
+++ b/contracts/Listing.sol
@@ -555,6 +555,7 @@ contract Listing is Initializable, ReentrancyGuardUpgradeable {
         require(block.timestamp < booking.start, "already started");
         require(!_depositReleased[bookingId], "deposit handled");
         require(_grossRentPaid[bookingId] == 0, "rent paid");
+        require(!booking.tokenised && booking.soldSqmu == 0, "tokenised");
 
         _cancelUpcomingBooking(bookingId, booking, msg.sender);
 


### PR DESCRIPTION
## Summary
- prevent landlords or the platform from cancelling bookings that have been tokenised or sold SQMU by adding an explicit revert

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d773dfa90c832ab9c56f484aaff7fa