### PR TITLE
Prevent deposit splits on tokenised bookings

### DIFF
--- a/contracts/Listing.sol
+++ b/contracts/Listing.sol
@@ -617,6 +617,8 @@ contract Listing is Initializable, ReentrancyGuardUpgradeable {
         require(tenantBps <= BPS_DENOMINATOR, "bps too high");
         Booking storage booking = _bookings[bookingId];
         require(booking.status == Status.ACTIVE || booking.status == Status.COMPLETED, "invalid status");
+        require(!booking.tokenised, "tokenised");
+        require(booking.soldSqmu == 0, "sqmu sold");
         require(!_depositReleased[bookingId], "deposit handled");
 
         _depositSplitProposals[bookingId] = DepositSplitProposal({exists: true, tenantBps: tenantBps, proposer: msg.sender});
@@ -643,6 +645,8 @@ contract Listing is Initializable, ReentrancyGuardUpgradeable {
         }
         Booking storage booking = _bookings[bookingId];
         require(booking.status == Status.ACTIVE || booking.status == Status.COMPLETED, "invalid status");
+        require(!booking.tokenised, "tokenised");
+        require(booking.soldSqmu == 0, "sqmu sold");
         require(!_depositReleased[bookingId], "deposit handled");
 
         DepositSplitProposal storage proposal = _depositSplitProposals[bookingId];


### PR DESCRIPTION
## Summary
- prevent landlords from proposing deposit splits when a booking is already tokenised or has SQMU sold
- enforce the same guard during platform confirmation to avoid releasing deposits for tokenised bookings

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d85be7eba8832aa22ae7c9a4a200ea