### PR TITLE
Handle deposit split proposals for tokenised bookings

### DIFF
--- a/notes/manual-qa.md
+++ b/notes/manual-qa.md
@@ -1,0 +1,4 @@
+# Manual QA Checklist
+
+## Smoke Tests
+- [ ] Deposit split proposal button remains disabled for tokenised bookings after loading booking details.


### PR DESCRIPTION
## Summary
- disable deposit split proposals for tokenised bookings and surface status messaging in the landlord deposit tools
- lock the tenant share input and clear pre-filled values whenever tokenisation blocks proposals
- add a manual smoke test reminder covering the disabled proposal button for tokenised bookings

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d85d4c4b20832a8db814ebb129f817