### PR TITLE
Filter investor holdings by URL listing and booking

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1403,6 +1403,11 @@ dl.summary-breakdown dd {
   gap: 12px;
 }
 
+.data-list .filter-note {
+  font-size: 0.82rem;
+  margin-bottom: -4px;
+}
+
 .metric-row {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- parse listing and booking query parameters on the investor dashboard to build a holdings filter
- limit SQMU-R holdings and rent cards to entries matching the requested listing/booking and surface a filter note
- add styling for the filter banner and refine status messaging to reflect filtered results

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d88240289c832aa05bcc1a40f8517b