### PR TITLE
Add modal confirmation for tenant cancellations

### DIFF
--- a/js/ui/confirm.js
+++ b/js/ui/confirm.js
@@ -1,0 +1,152 @@
+import { el, fmt } from './dom.js';
+
+let activeConfirmation = null;
+
+const closeActiveConfirmation = (decision = false) => {
+  if (activeConfirmation && typeof activeConfirmation.close === 'function') {
+    activeConfirmation.close(decision);
+  }
+};
+
+const createDetailRow = (label, value) => {
+  if (!label || value === undefined || value === null || value === '') {
+    return null;
+  }
+  return el('div', { class: 'confirmation-detail-row' }, [
+    el('dt', {}, label),
+    el('dd', {}, value),
+  ]);
+};
+
+export function confirmBookingAction({
+  title = 'Confirm action',
+  message = '',
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Go back',
+  booking = null,
+  footnote = '',
+} = {}) {
+  closeActiveConfirmation(false);
+
+  const detailRows = [];
+  const bookingId = booking?.bookingIdText || booking?.bookingId;
+  const listingTitle = booking?.listingTitle || '';
+  const startLabel = booking?.startLabel || booking?.start;
+  const endLabel = booking?.endLabel || booking?.end;
+  const deposit = booking?.deposit;
+  const rent = booking?.rent;
+  const period = booking?.periodLabel || booking?.period;
+
+  if (listingTitle) {
+    detailRows.push(createDetailRow('Listing', listingTitle));
+  }
+  if (bookingId) {
+    detailRows.push(createDetailRow('Booking', `#${bookingId}`));
+  }
+  if (startLabel || endLabel) {
+    const stayValue = [startLabel || '—', endLabel || '—'].join(' → ');
+    detailRows.push(createDetailRow('Stay', stayValue));
+  }
+  if (deposit !== undefined && deposit !== null) {
+    detailRows.push(createDetailRow('Deposit', `${fmt.usdc(deposit)} USDC`));
+  }
+  if (rent !== undefined && rent !== null) {
+    detailRows.push(createDetailRow('Rent', `${fmt.usdc(rent)} USDC`));
+  }
+  if (period) {
+    detailRows.push(createDetailRow('Payments', period));
+  }
+
+  return new Promise((resolve) => {
+    const previousActiveElement = document.activeElement;
+    const previousOverflow = document.body.style.overflow;
+
+    const dialogChildren = [
+      el('h3', { class: 'confirmation-title' }, title),
+    ];
+
+    if (message) {
+      dialogChildren.push(el('p', { class: 'confirmation-message' }, message));
+    }
+
+    if (detailRows.length > 0) {
+      dialogChildren.push(
+        el(
+          'dl',
+          { class: 'confirmation-details' },
+          detailRows.filter(Boolean),
+        ),
+      );
+    }
+
+    if (footnote) {
+      dialogChildren.push(el('p', { class: 'confirmation-footnote' }, footnote));
+    }
+
+    const cancelButton = el(
+      'button',
+      { type: 'button', class: 'inline-button confirmation-dismiss' },
+      cancelLabel,
+    );
+    const confirmButton = el(
+      'button',
+      { type: 'button', class: 'confirmation-confirm' },
+      confirmLabel,
+    );
+
+    const actions = el('div', { class: 'confirmation-actions' }, [cancelButton, confirmButton]);
+    dialogChildren.push(actions);
+
+    const dialog = el('div', { class: 'confirmation-dialog', role: 'document' }, dialogChildren);
+    const overlay = el('div', { class: 'confirmation-overlay', role: 'dialog', 'aria-modal': 'true' }, dialog);
+    overlay.tabIndex = -1;
+
+    let settled = false;
+    const cleanup = (decision) => {
+      if (settled) return;
+      settled = true;
+      overlay.removeEventListener('click', overlayClick);
+      overlay.removeEventListener('keydown', overlayKeydown);
+      cancelButton.removeEventListener('click', cancelHandler);
+      confirmButton.removeEventListener('click', confirmHandler);
+      overlay.remove();
+      document.body.style.overflow = previousOverflow;
+      activeConfirmation = null;
+      if (previousActiveElement && typeof previousActiveElement.focus === 'function') {
+        try {
+          previousActiveElement.focus();
+        } catch {}
+      }
+      resolve(decision);
+    };
+
+    const cancelHandler = () => cleanup(false);
+    const confirmHandler = () => cleanup(true);
+    const overlayClick = (event) => {
+      if (event.target === overlay) {
+        cleanup(false);
+      }
+    };
+    const overlayKeydown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        cleanup(false);
+      }
+    };
+
+    cancelButton.addEventListener('click', cancelHandler);
+    confirmButton.addEventListener('click', confirmHandler);
+    overlay.addEventListener('click', overlayClick);
+    overlay.addEventListener('keydown', overlayKeydown);
+
+    document.body.appendChild(overlay);
+    document.body.style.overflow = 'hidden';
+    activeConfirmation = { close: cleanup };
+
+    requestAnimationFrame(() => {
+      try {
+        confirmButton.focus();
+      } catch {}
+    });
+  });
+}

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1770,3 +1770,116 @@ section.card:not([hidden]),
 [data-collapsible-content][hidden] {
   display: none !important;
 }
+
+.confirmation-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(17, 17, 23, 0.52);
+}
+
+.confirmation-dialog {
+  width: min(420px, 100%);
+  background: var(--color-bg);
+  color: var(--color-text);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.confirmation-title {
+  margin: 0;
+  font-size: 1.16rem;
+  line-height: 1.3;
+}
+
+.confirmation-message {
+  margin: 0;
+  color: var(--color-muted-strong);
+}
+
+.confirmation-details {
+  margin: 0;
+  padding: 0;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface);
+}
+
+.confirmation-detail-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.confirmation-detail-row:last-of-type {
+  border-bottom: none;
+}
+
+.confirmation-detail-row dt {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.confirmation-detail-row dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.confirmation-footnote {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--color-muted);
+}
+
+.confirmation-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.confirmation-actions .confirmation-dismiss {
+  order: 0;
+}
+
+.confirmation-actions .confirmation-confirm {
+  min-width: 140px;
+}
+
+@media (max-width: 520px) {
+  .confirmation-dialog {
+    padding: 20px;
+    gap: 14px;
+  }
+
+  .confirmation-detail-row {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+
+  .confirmation-detail-row dd {
+    justify-self: start;
+  }
+
+  .confirmation-actions {
+    justify-content: stretch;
+  }
+
+  .confirmation-actions button {
+    flex: 1 1 auto;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the tenant cancellation confirm dialog with a sandbox-friendly modal overlay
- add a reusable confirmation helper that surfaces booking details and resolves asynchronously
- style the confirmation dialog for both desktop and mobile layouts

## Testing
- Manual verification via http://127.0.0.1:8000/tenant.html

------
https://chatgpt.com/codex/tasks/task_e_68d898608cac832a955fde591f08c695