### PR TITLE
Grant SQMU minter rights when approving tokenisation

### DIFF
--- a/contracts/Platform.sol
+++ b/contracts/Platform.sol
@@ -465,6 +465,11 @@ contract Platform is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         address listing = listingById[listingId];
         require(listing != address(0), "listing not found");
 
+        address sqmuToken_ = sqmuToken;
+        require(sqmuToken_ != address(0), "sqmu=0");
+
+        IR3ntSQMUManager(sqmuToken_).grantListingMinter(listing);
+
         IListingTokenisation(listing).approveTokenisation(bookingId);
     }
 


### PR DESCRIPTION
## Summary
- ensure `Platform.approveTokenisation` grants the listing SQMU minter rights before forwarding the approval

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d89934e6f8832aa3dfb34c30b63997