### PR TITLE
Add inline cancellation confirmation UI for tenants

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -926,6 +926,25 @@ footer {
   box-shadow: var(--shadow-subtle);
 }
 
+.card-footnote.cancel-confirmation {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--color-warning-text);
+  padding-top: 8px;
+  border-top: 1px dashed var(--color-border);
+}
+
+.card-footnote.cancel-confirmation .cancel-confirmation-message {
+  flex: 1 1 220px;
+}
+
+.card-footnote.cancel-confirmation .cancel-confirmation-dismiss {
+  flex: 0 0 auto;
+}
+
 .data-card.selectable {
   cursor: pointer;
   transition: border-color var(--transition-fast), box-shadow var(--transition-fast), transform var(--transition-fast);


### PR DESCRIPTION
## Summary
- replace the tenant booking cancellation confirm dialog with an inline confirmation flow that works in sandboxed contexts
- add styling for the inline cancellation prompt to fit the existing booking card layout

## Testing
- Not run (Warpcast web and mobile manual verification requires client access outside the container)


------
https://chatgpt.com/codex/tasks/task_e_68d89dbac504832ab14bd52f7118af79