### PR TITLE
Add tenant location detection with 50 km radius filter

### DIFF
--- a/js/listing-filters.js
+++ b/js/listing-filters.js
@@ -1,9 +1,48 @@
-import { latLonToGeohash } from './tools.js';
+import { latLonToGeohash, geohashToLatLon } from './tools.js';
 
 export const DEFAULT_LISTING_SORT_MODE = 'created-desc';
 export const LISTING_LOCATION_FILTER_PRECISION = 5;
 export const LISTING_LOCATION_FILTER_PATTERN = /^\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*$/;
 const DEFAULT_GEOHASH_PRECISION = 7;
+export const LISTING_LOCATION_FILTER_RADIUS_KM = 50;
+
+const EARTH_RADIUS_KM = 6371;
+
+function toRadians(deg) {
+  return (deg * Math.PI) / 180;
+}
+
+function haversineDistanceKm(lat1, lon1, lat2, lon2) {
+  if (!Number.isFinite(lat1) || !Number.isFinite(lon1) || !Number.isFinite(lat2) || !Number.isFinite(lon2)) {
+    return Number.NaN;
+  }
+  const dLat = toRadians(lat2 - lat1);
+  const dLon = toRadians(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) *
+      Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_KM * c;
+}
+
+function resolveEntryCoords(entry) {
+  if (!entry) return null;
+  const lat = Number(entry.lat);
+  const lon = Number(entry.lon);
+  if (Number.isFinite(lat) && Number.isFinite(lon)) {
+    return { lat, lon };
+  }
+  const geohash = typeof entry.geohash === 'string' ? entry.geohash.trim() : '';
+  if (!geohash) return null;
+  try {
+    const coords = geohashToLatLon(geohash);
+    if (coords && Number.isFinite(coords.lat) && Number.isFinite(coords.lon)) {
+      return { lat: coords.lat, lon: coords.lon };
+    }
+  } catch {}
+  return null;
+}
 
 export function parseLatLonStrict(latStr, lonStr) {
   const lat = Number(latStr);
@@ -124,11 +163,22 @@ export function parseLocationFilter(rawValue, options = {}) {
     locationPrecision = LISTING_LOCATION_FILTER_PRECISION,
     pattern = LISTING_LOCATION_FILTER_PATTERN,
     parseLatLon = parseLatLonStrict,
+    radiusKm = LISTING_LOCATION_FILTER_RADIUS_KM,
   } = options || {};
 
   const raw = typeof rawValue === 'string' ? rawValue.trim() : '';
   if (!raw) {
-    return { typed: false, applied: false, invalid: false, prefix: '', derivedFrom: null };
+    return {
+      typed: false,
+      applied: false,
+      invalid: false,
+      prefix: '',
+      derivedFrom: null,
+      mode: null,
+      lat: null,
+      lon: null,
+      radiusKm: null,
+    };
   }
 
   const latLonMatch = raw.match(pattern);
@@ -139,14 +189,45 @@ export function parseLocationFilter(rawValue, options = {}) {
       const prefix = geohash
         .slice(0, Math.min(locationPrecision, geohash.length))
         .toLowerCase();
-      return { typed: true, applied: true, invalid: false, prefix, derivedFrom: 'latlon' };
+      const effectiveRadius = Number.isFinite(radiusKm) && radiusKm > 0 ? Number(radiusKm) : LISTING_LOCATION_FILTER_RADIUS_KM;
+      return {
+        typed: true,
+        applied: true,
+        invalid: false,
+        prefix,
+        derivedFrom: 'latlon',
+        mode: 'radius',
+        lat,
+        lon,
+        radiusKm: effectiveRadius,
+      };
     } catch (err) {
       console.warn('Invalid latitude/longitude filter input', raw, err);
-      return { typed: true, applied: false, invalid: true, prefix: '', derivedFrom: 'latlon' };
+      return {
+        typed: true,
+        applied: false,
+        invalid: true,
+        prefix: '',
+        derivedFrom: 'latlon',
+        mode: null,
+        lat: null,
+        lon: null,
+        radiusKm: null,
+      };
     }
   }
 
-  return { typed: true, applied: false, invalid: true, prefix: '', derivedFrom: null };
+  return {
+    typed: true,
+    applied: false,
+    invalid: true,
+    prefix: '',
+    derivedFrom: null,
+    mode: null,
+    lat: null,
+    lon: null,
+    radiusKm: null,
+  };
 }
 
 export function applyListingFilters(records, options = {}) {
@@ -156,6 +237,7 @@ export function applyListingFilters(records, options = {}) {
     geohashPrecision = DEFAULT_GEOHASH_PRECISION,
     locationPrecision = LISTING_LOCATION_FILTER_PRECISION,
     parseLatLon,
+    radiusKm = LISTING_LOCATION_FILTER_RADIUS_KM,
   } = options || {};
 
   const list = Array.isArray(records) ? records : [];
@@ -163,10 +245,23 @@ export function applyListingFilters(records, options = {}) {
     geohashPrecision,
     locationPrecision,
     parseLatLon,
+    radiusKm,
   });
 
   let filtered = list;
-  if (filterInfo.applied && filterInfo.prefix) {
+  if (filterInfo.mode === 'radius' && Number.isFinite(filterInfo.lat) && Number.isFinite(filterInfo.lon)) {
+    const effectiveRadius = Number.isFinite(filterInfo.radiusKm) && filterInfo.radiusKm > 0
+      ? Number(filterInfo.radiusKm)
+      : Number(radiusKm);
+    filterInfo.radiusKm = effectiveRadius;
+    filtered = list.filter((entry) => {
+      const coords = resolveEntryCoords(entry);
+      if (!coords) return false;
+      const dist = haversineDistanceKm(filterInfo.lat, filterInfo.lon, coords.lat, coords.lon);
+      return Number.isFinite(dist) && dist <= effectiveRadius;
+    });
+  } else if (filterInfo.applied && filterInfo.prefix) {
+    filterInfo.mode = 'prefix';
     const prefix = filterInfo.prefix;
     filtered = list.filter((entry) => {
       const geohash = typeof entry?.geohash === 'string' ? entry.geohash.toLowerCase() : '';

--- a/tenant.html
+++ b/tenant.html
@@ -116,6 +116,7 @@
               <span>Location filter</span>
               <input id="listingLocationFilter" placeholder="Latitude,Longitude" autocomplete="off" spellcheck="false" />
             </label>
+            <button type="button" id="listingLocationDetect" class="inline-button">Detect location</button>
             <button type="button" id="listingLocationClear" class="inline-button">Clear</button>
           </div>
           <div id="listings"></div>


### PR DESCRIPTION
## Summary
- add a Detect location control to the tenant listing filters and wire it into browser geolocation
- apply a consistent 50 km radius filter for detected or manually entered coordinates when filtering listings
- update tenant filter messaging to reflect radius-based results

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da3030f718832a9e4a9f6b42ce2c13