### PR TITLE
Fix tenant booking filter to include cancelled stays

### DIFF
--- a/js/tenant.js
+++ b/js/tenant.js
@@ -2008,19 +2008,17 @@ function renderBookings(records, emptyMessage = 'No bookings found for this wall
     filterEl.value = bookingFilterMode;
   }
 
-  const filtered = records.filter((record) => {
-    if (bookingFilterMode === 'active') {
-      return record.isActive;
-    }
-    return !record.isCancelled;
-  });
+  const filtered =
+    bookingFilterMode === 'active'
+      ? records.filter((record) => record.isActive)
+      : [...records];
 
   if (filtered.length === 0) {
     if (statusEl) {
       statusEl.textContent =
         bookingFilterMode === 'active'
           ? 'No active bookings found. Switch the filter to view past bookings.'
-          : 'No bookings found. Cancelled bookings are hidden.';
+          : 'No bookings found. Cancelled bookings are included in this view.';
     }
     closeTokenProposal();
     return;

--- a/tenant.html
+++ b/tenant.html
@@ -57,7 +57,7 @@
           <span>Show</span>
           <select id="bookingFilter">
             <option value="active">Active bookings</option>
-            <option value="all">All bookings (cancelled hidden)</option>
+            <option value="all">All bookings</option>
           </select>
         </label>
       </div>


### PR DESCRIPTION
## Summary
- update the tenant bookings filter label to reflect that cancelled stays are shown
- ensure the "All" filter keeps cancelled bookings in the rendered list and adjust the empty-state copy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db01be3c14832a9bad5efff435a7bf