### PR TITLE
Refactor carousel layout into shared class

### DIFF
--- a/js/landlord.js
+++ b/js/landlord.js
@@ -1432,7 +1432,7 @@ function renderLandlordListingCard(listing) {
     class: 'inline-button small',
   }, 'Refresh');
   const bookingsStatus = el('div', { class: 'bookings-status' }, 'Press refresh to load bookings.');
-  const bookingsList = el('div', { class: 'bookings-list' });
+  const bookingsList = el('div', { class: 'bookings-list carousel-track' });
   const bookingsHeader = el('div', { class: 'bookings-header' }, [
     el('h3', {}, 'Bookings'),
     bookingsRefresh,

--- a/landlord.html
+++ b/landlord.html
@@ -213,7 +213,7 @@
         </label>
         <button type="button" id="listingLocationClear" class="inline-button">Clear</button>
       </div>
-      <div id="landlordListings" class="muted">Connect wallet to load your listings.</div>
+      <div id="landlordListings" class="muted carousel-track">Connect wallet to load your listings.</div>
     </div>
   </section>
 

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -744,10 +744,7 @@ footer {
   box-shadow: var(--color-selected-shadow);
 }
 
-#landlordListings,
-#listings,
-#bookingsList {
-  margin-top: 12px;
+.carousel-track {
   display: flex;
   gap: 16px;
   overflow-x: auto;
@@ -760,21 +757,23 @@ footer {
   overscroll-behavior-inline: contain;
 }
 
+#landlordListings,
+#listings,
+#bookingsList {
+  margin-top: 12px;
+}
+
 #listings {
   margin-top: 20px;
 }
 
-#landlordListings > *,
-#listings > *,
-#bookingsList > * {
+.carousel-track > * {
   flex: 0 0 clamp(260px, 80vw, 340px);
   scroll-snap-align: start;
   scroll-snap-stop: always;
 }
 
-#landlordListings:focus-visible,
-#listings:focus-visible,
-#bookingsList:focus-visible {
+.carousel-track:focus-visible {
   outline: 2px solid var(--color-link);
   outline-offset: 4px;
 }
@@ -1248,10 +1247,8 @@ dl.summary-breakdown dd {
   color: var(--color-muted);
 }
 
-.bookings-list {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+.bookings-list:not(.carousel-track) > * + * {
+  margin-top: 12px;
 }
 
 .booking-entry {

--- a/tenant.html
+++ b/tenant.html
@@ -61,7 +61,7 @@
           </select>
         </label>
       </div>
-      <div id="bookingsList" class="bookings-list"></div>
+      <div id="bookingsList" class="bookings-list carousel-track"></div>
       <div id="tokenProposalPanel" class="token-proposal-card" hidden></div>
     </div>
   </section>
@@ -128,7 +128,7 @@
             <button type="button" id="listingLocationDetect" class="inline-button">Detect location</button>
             <button type="button" id="listingLocationClear" class="inline-button">Clear</button>
           </div>
-          <div id="listings"></div>
+          <div id="listings" class="carousel-track"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a reusable `.carousel-track` helper so listing and booking strips share the same horizontal scroll behaviour
- loosen the `.bookings-list` layout rules while preserving vertical spacing for non-carousel contexts
- update landlord and tenant views (including dynamic renderers) to opt into the shared carousel class

## Testing
- Manual verification in headless Chromium (tenant carousel)


------
https://chatgpt.com/codex/tasks/task_e_68db0cc71a50832a8f213da489b2f796