### PR TITLE
Add FAQ link to navigation and standardize FAQ footer

### DIFF
--- a/FIDTest.html
+++ b/FIDTest.html
@@ -39,6 +39,7 @@
     <a href="./landlord.html">Landlord</a>
     <a href="./investor.html">Investor</a>
     <a href="./agent.html">Agent</a>
+    <a href="./faq.html">FAQ</a>
     <span class="version-badge" data-version></span>
   </nav>
   <div id="status">Loading…</div>

--- a/agent.html
+++ b/agent.html
@@ -26,6 +26,7 @@
     <a href="./landlord.html">Landlord</a>
     <a href="./investor.html">Investor</a>
     <a href="./agent.html">Agent</a>
+    <a href="./faq.html">FAQ</a>
     <span class="version-badge" data-version></span>
   </nav>
   <div id="notificationTray" class="notification-tray"></div>

--- a/faq.html
+++ b/faq.html
@@ -165,6 +165,7 @@
       <a href="./landlord.html">Landlord</a>
       <a href="./investor.html">Investor</a>
       <a href="./agent.html">Agent</a>
+      <a href="./faq.html">FAQ</a>
       <span class="version-badge" data-version></span>
     </nav>
 
@@ -372,7 +373,7 @@
     </main>
 
     <footer>
-      &copy; <span data-year></span> r3nt. This page describes user-facing flows; it omits deep technical implementation details. For integration or audits, consult the project documentation.
+      r3nt by SQMU. USDC. Arbitrum.
     </footer>
   </div>
 
@@ -386,18 +387,12 @@
       if (badge) badge.textContent = `Build ${APP_VERSION}`;
     };
 
-    const applyYear = () => {
-      const target = document.querySelector('[data-year]');
-      if (target) target.textContent = new Date().getFullYear();
-    };
-
     const backButton = document.querySelector('[data-back-button]');
     const backController = createBackController({ sdk, button: backButton });
     backController.update();
 
     const boot = () => {
       applyVersionBadge();
-      applyYear();
     };
 
     if (document.readyState === 'loading') {

--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
       <a href="./landlord.html">Landlord</a>
       <a href="./investor.html">Investor</a>
       <a href="./agent.html">Agent</a>
+      <a href="./faq.html">FAQ</a>
       <span class="version-badge" data-version></span>
     </nav>
 

--- a/investor.html
+++ b/investor.html
@@ -26,6 +26,7 @@
     <a href="./landlord.html">Landlord</a>
     <a href="./investor.html">Investor</a>
     <a href="./agent.html">Agent</a>
+    <a href="./faq.html">FAQ</a>
     <span class="version-badge" data-version></span>
   </nav>
   <div id="notificationTray" class="notification-tray"></div>

--- a/landlord.html
+++ b/landlord.html
@@ -43,6 +43,7 @@
     <a href="./landlord.html">Landlord</a>
     <a href="./investor.html">Investor</a>
     <a href="./agent.html">Agent</a>
+    <a href="./faq.html">FAQ</a>
     <span class="version-badge" data-version></span>
   </nav>
   <div id="notificationTray" class="notification-tray"></div>

--- a/platform.html
+++ b/platform.html
@@ -24,6 +24,7 @@
     <a href="./landlord.html">Landlord</a>
     <a href="./investor.html">Investor</a>
     <a href="./agent.html">Agent</a>
+    <a href="./faq.html">FAQ</a>
     <span class="version-badge" data-version></span>
   </nav>
   <div id="notificationTray" class="notification-tray"></div>

--- a/tenant.html
+++ b/tenant.html
@@ -29,6 +29,7 @@
     <a href="./landlord.html">Landlord</a>
     <a href="./investor.html">Investor</a>
     <a href="./agent.html">Agent</a>
+    <a href="./faq.html">FAQ</a>
     <span class="version-badge" data-version></span>
   </nav>
   <div id="notificationTray" class="notification-tray"></div>


### PR DESCRIPTION
## Summary
- add the FAQ route to the primary navigation across all pages so it is easy to access from the header
- align the FAQ page footer copy with the standard site footer and remove the unused year helper

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68db1c1a6a84832a8563565b672229a9