### PR TITLE
Replace cadence terminology with plain language

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The per-property clone that handles bookings, deposit escrow, tokenisation and r
 
 ### Tokenisation (Optional)
 - Landlord or tenant proposes tokenisation with `proposeTokenisation`, specifying
-  `totalSqmu`, `pricePerSqmu`, `feeBps` and periodic rent cadence (`Period` enum).
+  `totalSqmu`, `pricePerSqmu`, `feeBps` and periodic rent intervals (`Period` enum).
 - The platform approves via `approveTokenisation` to ensure the raise aligns with remaining
   rent expectations.
 - Investors call `invest(bookingId, sqmuAmount)`; USDC is collected, the landlord receives

--- a/contracts/Agent.sol
+++ b/contracts/Agent.sol
@@ -19,7 +19,7 @@ interface IListingLike {
         DEFAULTED
     }
 
-    /// @notice Supported rent payment cadences (mirrors `Listing.Period`).
+    /// @notice Supported rent payment intervals (mirrors `Listing.Period`).
     enum Period {
         NONE,
         DAY,
@@ -305,7 +305,7 @@ contract Agent is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentrancy
      * @param totalSqmu_ Total number of SQMU-R tokens that will be minted.
      * @param pricePerSqmu_ Price per SQMU-R token denominated in USDC (6 decimals).
      * @param feeBps_ Platform fee (basis points) applied to investments.
-     * @param period_ Informational rent distribution cadence passed through to the listing.
+     * @param period_ Informational rent distribution interval passed through to the listing.
      */
     function configureFundraising(
         uint256 totalSqmu_,

--- a/contracts/Listing.sol
+++ b/contracts/Listing.sol
@@ -45,7 +45,7 @@ contract Listing is Initializable, ReentrancyGuardUpgradeable {
         DEFAULTED
     }
 
-    /// @notice Supported rent payment cadences.
+    /// @notice Supported rent payment intervals.
     enum Period {
         NONE,
         DAY,
@@ -391,7 +391,7 @@ contract Listing is Initializable, ReentrancyGuardUpgradeable {
      *         platform fees for reference and escrows the security deposit.
      * @param start Booking start timestamp (seconds).
      * @param end Booking end timestamp (seconds).
-     * @param period Rent payment cadence selected by the tenant.
+     * @param period Rent payment interval selected by the tenant.
      * @return bookingId Identifier assigned to the new booking.
      */
     function book(uint64 start, uint64 end, Period period) external nonReentrant returns (uint256 bookingId) {
@@ -689,7 +689,7 @@ contract Listing is Initializable, ReentrancyGuardUpgradeable {
      * @param totalSqmu Total number of SQMU-R tokens that will be minted if approved.
      * @param pricePerSqmu Price per SQMU-R token denominated in USDC (6 decimals).
      * @param feeBps Platform fee applied to investments (basis points).
-     * @param period Rent distribution cadence for informational purposes.
+     * @param period Rent distribution interval for informational purposes.
      */
     function proposeTokenisation(
         uint256 bookingId,

--- a/faq.html
+++ b/faq.html
@@ -200,7 +200,7 @@
           <ol class="step-list">
             <li><strong>Browse listings.</strong> Use filters to find a property. Review rate, deposit and any view-pass requirements.</li>
             <li><strong>Select dates and book.</strong> Pick check-in/check-out and confirm. The app checks availability and escrows your security deposit.</li>
-            <li><strong>Pay rent on cadence.</strong> Use <code>Pay rent</code> for weekly/monthly payments as agreed. If the booking is tokenised, your rent is still paid in-app; it’s distributed to SQMU-R holders behind the scenes.</li>
+            <li><strong>Pay rent in agreed intervals.</strong> Use <code>Pay rent</code> for weekly/monthly payments as agreed. If the booking is tokenised, your rent is still paid in-app; it’s distributed to SQMU-R holders behind the scenes.</li>
             <li><strong>Check status.</strong> Track booking, payments and deposit status in your dashboard.</li>
             <li><strong>Deposit return.</strong> After checkout, the landlord proposes a deposit split; once finalised, your portion is released automatically.</li>
           </ol>
@@ -259,7 +259,7 @@
             </p>
             <h4>Who benefits?</h4>
             <ul>
-              <li><strong>Tenant:</strong> Budget-friendly cadence.</li>
+              <li><strong>Tenant:</strong> Budget-friendly installments.</li>
               <li><strong>Investors:</strong> Receive periodic payments with a premium.</li>
               <li><strong>Landlord:</strong> May still receive regular rent or a portion via structure.</li>
             </ul>
@@ -314,7 +314,7 @@
               <p>Deposits are escrowed on-chain. After checkout, the landlord proposes a split and, once confirmed, your share is automatically released.</p>
             </details>
             <details class="faq-item"><summary>Can I switch from monthly to weekly?</summary>
-              <p>If the listing supports multiple cadences, you can change at the next billing cycle. Fees may adjust accordingly.</p>
+              <p>If the listing supports multiple payment intervals, you can change at the next billing cycle. Fees may adjust accordingly.</p>
             </details>
           </div>
         </div>

--- a/js/investor.js
+++ b/js/investor.js
@@ -360,7 +360,7 @@ function formatPeriodLabel(periodValue) {
   if (Object.prototype.hasOwnProperty.call(PERIOD_LABELS, numeric)) {
     return PERIOD_LABELS[numeric];
   }
-  return numeric > 0 ? 'Custom cadence' : PERIOD_LABELS[0];
+  return numeric > 0 ? 'Custom payment interval' : PERIOD_LABELS[0];
 }
 
 function percentOf(numerator, denominator) {

--- a/js/landlord.js
+++ b/js/landlord.js
@@ -1067,7 +1067,7 @@ function renderLandlordBookingTokenSection(record) {
       createBookingDetailElement('Proposed price', `${fmt.usdc(record.pending?.pricePerSqmu)} USDC`)
     );
     details.appendChild(createBookingDetailElement('Proposed fee', fmt.bps(record.pending?.feeBps)));
-    details.appendChild(createBookingDetailElement('Proposed cadence', record.pendingPeriodLabel || 'Custom'));
+    details.appendChild(createBookingDetailElement('Proposed payment interval', record.pendingPeriodLabel || 'Custom'));
     const proposerText = record.pendingProposerShort || (record.pendingProposer || '—');
     details.appendChild(
       createBookingDetailElement('Proposer', proposerText, { tooltip: record.pendingProposer || undefined })
@@ -2560,7 +2560,7 @@ function createTokenTools(listing) {
 
   const intro = document.createElement('p');
   intro.className = 'muted';
-  intro.textContent = 'Define SQMU supply, pricing and cadence for bookings you manage. Platform approval is required before investors can participate.';
+  intro.textContent = 'Define SQMU supply, pricing and payment intervals for bookings you manage. Platform approval is required before investors can participate.';
   content.appendChild(intro);
 
   const bookingLabel = document.createElement('label');

--- a/js/tenant.js
+++ b/js/tenant.js
@@ -579,9 +579,9 @@ function calculateInstallmentCap(totalRent, startTs, endTs, periodDays) {
   const rent = typeof totalRent === 'bigint' ? totalRent : BigInt(totalRent || 0);
   const start = typeof startTs === 'bigint' ? startTs : BigInt(startTs || 0);
   const end = typeof endTs === 'bigint' ? endTs : BigInt(endTs || 0);
-  const cadenceDays = typeof periodDays === 'bigint' ? periodDays : BigInt(periodDays || 0);
+  const intervalDays = typeof periodDays === 'bigint' ? periodDays : BigInt(periodDays || 0);
   if (rent <= 0n) return 0n;
-  if (cadenceDays <= 0n) return rent;
+  if (intervalDays <= 0n) return rent;
   if (end <= start) return rent;
 
   let duration = end - start;
@@ -593,7 +593,7 @@ function calculateInstallmentCap(totalRent, startTs, endTs, periodDays) {
     dailyRate += 1n;
   }
 
-  let installment = dailyRate * cadenceDays;
+  let installment = dailyRate * intervalDays;
   if (installment > rent) {
     installment = rent;
   }
@@ -1606,7 +1606,7 @@ async function submitTokenisationProposalForTenant(record, { amount, totalSqmu, 
   }
   const requiredKey = getPeriodKeyFromValue(target.periodValue);
   if (requiredKey && requiredKey !== periodKey) {
-    notify({ message: `Booking cadence is fixed to ${target.periodLabel.toLowerCase()}.`, variant: 'warning', role: 'tenant', timeout: 5000 });
+    notify({ message: `Booking payment interval is fixed to ${target.periodLabel.toLowerCase()}.`, variant: 'warning', role: 'tenant', timeout: 5000 });
     return false;
   }
 
@@ -2462,13 +2462,13 @@ async function bookListing(listing = selectedListing){
 
     const depositMsg = deposit > 0n ? `${fmt.usdc(deposit)} USDC deposit` : 'no deposit';
     const rentMsg = rent > 0n ? `${fmt.usdc(rent)} USDC rent` : '0 USDC rent';
-    const cadenceMsg = installmentCap > 0n
+    const intervalMsg = installmentCap > 0n
       ? `${selectedPeriod.label} payments up to ${fmt.usdc(installmentCap)} USDC`
       : `${selectedPeriod.label} payments`;
     const approvalNotice = needsApproval
       ? ' Confirm the approval and booking when prompted.'
       : '';
-    els.status.textContent = `Booking stay (${depositMsg}; rent due later: ${rentMsg}; ${cadenceMsg}).${approvalNotice}`;
+    els.status.textContent = `Booking stay (${depositMsg}; rent due later: ${rentMsg}; ${intervalMsg}).${approvalNotice}`;
 
     let walletSendUnsupported = false;
     let batchedSuccess = false;


### PR DESCRIPTION
## Summary
- replace cadence references with interval or installment terminology across docs and UI copy
- update tenant and landlord flows to surface "payment interval" wording in notifications and helper text
- refresh Solidity comments to describe payment intervals for booking and tokenisation periods

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db1fbdf6bc832a9541639c8b7788e1