### PR TITLE
Display tenant platform fee basis points on tenant bookings

### DIFF
--- a/js/tenant.js
+++ b/js/tenant.js
@@ -2144,6 +2144,7 @@ function renderBookings(records, emptyMessage = 'No bookings found for this wall
       period: record.periodLabel,
       depositUSDC: record.deposit,
       rentUSDC: record.grossRent,
+      tenantFeeBps: record.tenantFeeBps,
       status: record.statusLabel,
       statusClass: record.statusClass,
       actions,

--- a/js/ui/cards.js
+++ b/js/ui/cards.js
@@ -59,12 +59,18 @@ export function BookingCard({
   period,
   depositUSDC,
   rentUSDC,
+  tenantFeeBps,
   status,
   statusClass,
   actions = [],
 }) {
   const periodText = (periodLabel(period) || '').trim();
   const showPeriod = Boolean(periodText) && periodText !== '—';
+  const tenantFeeAvailable = tenantFeeBps !== undefined && tenantFeeBps !== null;
+  const tenantFeePill = tenantFeeAvailable ? Pill(`Tenant fee ${fmt.bps(tenantFeeBps)}`) : null;
+  if (tenantFeePill) {
+    tenantFeePill.dataset.role = 'tenant-fee-bps';
+  }
   return el('div', { class: 'card data-card booking-entry', dataset: { bookingId, listingId } }, [
     el('div', { class: 'card-header' }, [
       el('strong', {}, `Booking #${bookingId}`),
@@ -73,6 +79,7 @@ export function BookingCard({
         showPeriod ? Pill(periodText) : null,
         depositUSDC != null ? Pill(`Deposit ${fmt.usdc(depositUSDC)} USDC`) : null,
         rentUSDC != null ? Pill(`Rent ${fmt.usdc(rentUSDC)} USDC`) : null,
+        tenantFeePill,
         status
           ? Pill(
               status,


### PR DESCRIPTION
## Summary
- show the tenant platform fee basis points on booking cards in the tenant view
- pass the stored tenant fee configuration through to the shared booking card component

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e07ccd0b80832aafb435b5c3126f21