### PR TITLE
Ensure planner listings can shrink in carousel

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -765,6 +765,7 @@ footer {
 
 #listings {
   margin-top: 20px;
+  min-width: 0;
 }
 
 .carousel-track > * {
@@ -1161,6 +1162,7 @@ footer {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  min-width: 0;
 }
 
 .planner-form[hidden] + .planner-listings {


### PR DESCRIPTION
## Summary
- add a min-width guard to the planner listings column so it can shrink within the minmax grid
- apply the same safeguard to the listings list container to prevent overflow across browsers

## Testing
- python -m http.server 8000 (manual verification of carousel layout)


------
https://chatgpt.com/codex/tasks/task_e_68e0e4828e94832aa79fb55737944569