### PR TITLE
Make brand link navigate home and remove duplicate nav link

### DIFF
--- a/FIDTest.html
+++ b/FIDTest.html
@@ -28,13 +28,12 @@
 </head>
 <body class="page-compact">
   <header>
-    <div class="brand">r3nt by SQMU</div>
+    <a class="brand" href="./index.html">r3nt by SQMU</a>
   </header>
 
   <div class="muted beta-note">early beta.</div>
 
   <nav>
-    <a href="./index.html">Home</a>
     <a href="./tenant.html">Tenant</a>
     <a href="./landlord.html">Landlord</a>
     <a href="./investor.html">Investor</a>

--- a/agent.html
+++ b/agent.html
@@ -11,7 +11,7 @@
 </head>
 <body class="page-narrow">
   <header>
-    <div class="brand">r3nt by SQMU</div>
+    <a class="brand" href="./index.html">r3nt by SQMU</a>
   </header>
 
   <div class="muted beta-note">early beta.</div>
@@ -21,7 +21,6 @@
       <span aria-hidden="true">←</span>
       Back
     </button>
-    <a href="./index.html">Home</a>
     <a href="./tenant.html">Tenant</a>
     <a href="./landlord.html">Landlord</a>
     <a href="./investor.html">Investor</a>

--- a/faq.html
+++ b/faq.html
@@ -149,7 +149,7 @@
 </head>
 <body class="page-wide page-faq">
   <header>
-    <div class="brand">r3nt by SQMU</div>
+    <a class="brand" href="./index.html">r3nt by SQMU</a>
   </header>
 
   <div class="muted beta-note">early beta.</div>
@@ -159,7 +159,6 @@
       <span aria-hidden="true">←</span>
       Back
     </button>
-    <a href="./index.html">Home</a>
     <a href="./tenant.html">Tenant</a>
     <a href="./landlord.html">Landlord</a>
     <a href="./investor.html">Investor</a>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 <body class="page-home">
   <div class="wrap">
     <header>
-      <div class="brand">r3nt by SQMU</div>
+      <a class="brand" href="./index.html">r3nt by SQMU</a>
     </header>
 
     <div class="muted beta-note">early beta.</div>
@@ -38,7 +38,6 @@
         <span aria-hidden="true">←</span>
         Back
       </button>
-      <a href="./index.html">Home</a>
       <a href="./tenant.html">Tenant</a>
       <a href="./landlord.html">Landlord</a>
       <a href="./investor.html">Investor</a>

--- a/investor.html
+++ b/investor.html
@@ -11,7 +11,7 @@
 </head>
 <body class="page-narrow">
   <header>
-    <div class="brand">r3nt by SQMU</div>
+    <a class="brand" href="./index.html">r3nt by SQMU</a>
   </header>
 
   <div class="muted beta-note">early beta.</div>
@@ -21,7 +21,6 @@
       <span aria-hidden="true">←</span>
       Back
     </button>
-    <a href="./index.html">Home</a>
     <a href="./tenant.html">Tenant</a>
     <a href="./landlord.html">Landlord</a>
     <a href="./investor.html">Investor</a>

--- a/landlord.html
+++ b/landlord.html
@@ -28,7 +28,7 @@
 </head>
 <body class="page-compact">
   <header>
-    <div class="brand">r3nt by SQMU</div>
+    <a class="brand" href="./index.html">r3nt by SQMU</a>
   </header>
 
   <div class="muted beta-note">early beta.</div>
@@ -38,7 +38,6 @@
       <span aria-hidden="true">←</span>
       Back
     </button>
-    <a href="./index.html">Home</a>
     <a href="./tenant.html">Tenant</a>
     <a href="./landlord.html">Landlord</a>
     <a href="./investor.html">Investor</a>

--- a/platform.html
+++ b/platform.html
@@ -13,13 +13,12 @@
 </head>
 <body class="page-narrow">
   <header>
-    <div class="brand">r3nt by SQMU</div>
+    <a class="brand" href="./index.html">r3nt by SQMU</a>
   </header>
 
   <div class="muted beta-note">early beta.</div>
 
   <nav>
-    <a href="./index.html">Home</a>
     <a href="./tenant.html">Tenant</a>
     <a href="./landlord.html">Landlord</a>
     <a href="./investor.html">Investor</a>

--- a/tenant.html
+++ b/tenant.html
@@ -14,7 +14,7 @@
 </head>
 <body class="page-compact">
   <header>
-    <div class="brand">r3nt by SQMU</div>
+    <a class="brand" href="./index.html">r3nt by SQMU</a>
   </header>
 
   <div class="muted beta-note">early beta.</div>
@@ -24,7 +24,6 @@
       <span aria-hidden="true">←</span>
       Back
     </button>
-    <a href="./index.html">Home</a>
     <a href="./tenant.html">Tenant</a>
     <a href="./landlord.html">Landlord</a>
     <a href="./investor.html">Investor</a>


### PR DESCRIPTION
## Summary
- convert the header brand element into an anchor linking back to the homepage across all templates
- remove the redundant Home navigation entry now that the brand serves as the home link

## Testing
- not run (static HTML update)


------
https://chatgpt.com/codex/tasks/task_e_68e0ec87d360832a99ef74d6b1b5d446