### PR TITLE
Prompt users to add r3nt mini app after engagement

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,6 +149,7 @@
     import { sdk } from 'https://esm.sh/@farcaster/miniapp-sdk';
     import { APP_VERSION } from './js/config.js';
     import createBackController from './js/back-navigation.js';
+    import { initializeAddToCollectionPrompt } from './js/add-to-collection.js';
 
     const applyVersionBadge = () => {
       const badge = document.querySelector('[data-version]');
@@ -158,6 +159,7 @@
     const backButton = document.querySelector('[data-back-button]');
     const backController = createBackController({ sdk, button: backButton });
     backController.update();
+    initializeAddToCollectionPrompt({ sdk });
 
     const boot = () => {
       applyVersionBadge();

--- a/js/add-to-collection.js
+++ b/js/add-to-collection.js
@@ -1,0 +1,115 @@
+const DEFAULT_DELAY_MS = 60_000;
+const DEFAULT_IDLE_THRESHOLD_MS = 15_000;
+const SAMPLE_INTERVAL_MS = 1_000;
+
+let hasPromptedAddMiniApp = false;
+let activeController = null;
+
+const engagementEvents = [
+  { target: window, name: 'pointerdown', options: { passive: true } },
+  { target: window, name: 'touchstart', options: { passive: true } },
+  { target: window, name: 'keydown', options: false },
+  { target: window, name: 'scroll', options: { passive: true } },
+];
+
+function attachEngagementListeners(handler) {
+  engagementEvents.forEach(({ target, name, options }) => {
+    target.addEventListener(name, handler, options);
+  });
+}
+
+function detachEngagementListeners(handler) {
+  engagementEvents.forEach(({ target, name, options }) => {
+    target.removeEventListener(name, handler, options);
+  });
+}
+
+export function initializeAddToCollectionPrompt({
+  sdk,
+  delayMs = DEFAULT_DELAY_MS,
+  idleThresholdMs = DEFAULT_IDLE_THRESHOLD_MS,
+} = {}) {
+  if (hasPromptedAddMiniApp) {
+    return () => {};
+  }
+  if (!sdk || typeof sdk.actions?.addMiniApp !== 'function') {
+    return () => {};
+  }
+  if (activeController) {
+    return activeController.dispose;
+  }
+
+  let disposed = false;
+  let engagedMs = 0;
+  let lastInteractionAt = 0;
+  let intervalId = 0;
+
+  const maybeTriggerPrompt = async () => {
+    if (disposed || hasPromptedAddMiniApp) {
+      return;
+    }
+    if (engagedMs < delayMs) {
+      return;
+    }
+    hasPromptedAddMiniApp = true;
+    cleanup();
+    try {
+      await sdk.actions.addMiniApp();
+    } catch (error) {
+      console.warn('[r3nt] addMiniApp prompt could not be shown', error);
+    }
+  };
+
+  const sampleEngagement = () => {
+    if (disposed || hasPromptedAddMiniApp || !lastInteractionAt) {
+      return;
+    }
+    const now = Date.now();
+    const sinceLastInteraction = now - lastInteractionAt;
+    if (sinceLastInteraction <= idleThresholdMs) {
+      engagedMs = Math.min(engagedMs + SAMPLE_INTERVAL_MS, delayMs);
+      maybeTriggerPrompt();
+    }
+  };
+
+  const markInteraction = () => {
+    if (disposed || hasPromptedAddMiniApp) {
+      return;
+    }
+    lastInteractionAt = Date.now();
+    if (!intervalId) {
+      intervalId = window.setInterval(sampleEngagement, SAMPLE_INTERVAL_MS);
+    }
+  };
+
+  const handleVisibilityChange = () => {
+    if (disposed || hasPromptedAddMiniApp) {
+      return;
+    }
+    if (document.visibilityState === 'hidden') {
+      lastInteractionAt = 0;
+    } else if (document.visibilityState === 'visible') {
+      markInteraction();
+    }
+  };
+
+  const cleanup = () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    detachEngagementListeners(markInteraction);
+    document.removeEventListener('visibilitychange', handleVisibilityChange);
+    if (intervalId) {
+      window.clearInterval(intervalId);
+      intervalId = 0;
+    }
+    activeController = null;
+  };
+
+  attachEngagementListeners(markInteraction);
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+
+  activeController = { dispose: cleanup };
+  return cleanup;
+}

--- a/js/agent.js
+++ b/js/agent.js
@@ -3,6 +3,7 @@ import { createPublicClient, http, encodeFunctionData, parseUnits } from 'https:
 import { arbitrum } from 'https://esm.sh/viem/chains';
 import { notify, mountNotificationCenter } from './notifications.js';
 import { requestWalletSendCalls, isUserRejectedRequestError, extractErrorMessage } from './wallet.js';
+import { initializeAddToCollectionPrompt } from './add-to-collection.js';
 import {
   RPC_URL,
   LISTING_ABI,
@@ -81,6 +82,7 @@ const backButton = document.querySelector('[data-back-button]');
 const backController = createBackController({ sdk, button: backButton });
 let agentViewBackEntry = null;
 backController.update();
+initializeAddToCollectionPrompt({ sdk });
 
 function setStatus(message) {
   if (els.status) {

--- a/js/investor.js
+++ b/js/investor.js
@@ -4,6 +4,7 @@ import { arbitrum } from 'https://esm.sh/viem/chains';
 import { notify, mountNotificationCenter } from './notifications.js';
 import { requestWalletSendCalls, isUserRejectedRequestError } from './wallet.js';
 import { sqmuTokenIdentity } from './tools.js';
+import { initializeAddToCollectionPrompt } from './add-to-collection.js';
 import {
   RPC_URL,
   PLATFORM_ADDRESS,
@@ -56,6 +57,7 @@ const investorEventRefreshState = { timer: null, messages: new Set(), running: f
 const backButton = document.querySelector('[data-back-button]');
 const backController = createBackController({ sdk, button: backButton });
 backController.update();
+initializeAddToCollectionPrompt({ sdk });
 
 function isHexAddress(value) {
   return typeof value === 'string' && /^0x[0-9a-fA-F]{40}$/.test(value);

--- a/js/landlord.js
+++ b/js/landlord.js
@@ -14,6 +14,7 @@ import { BookingCard, TokenisationCard } from './ui/cards.js';
 import { createCollapsibleSection, mountCollapsibles } from './ui/accordion.js';
 import { el, fmt } from './ui/dom.js';
 import { createOpenMapButton } from './map-assist.js';
+import { initializeAddToCollectionPrompt } from './add-to-collection.js';
 import {
   PLATFORM_ADDRESS,
   PLATFORM_ABI,
@@ -224,6 +225,7 @@ function handleDeactivateListing(listing) {
 const backButton = document.querySelector('[data-back-button]');
 const backController = createBackController({ sdk, button: backButton });
 backController.update();
+initializeAddToCollectionPrompt({ sdk });
 
 const checkpointLabels = {
   basics: 'Basics',

--- a/js/tenant.js
+++ b/js/tenant.js
@@ -15,6 +15,7 @@ import {
   LISTING_LOCATION_FILTER_RADIUS_KM,
 } from './listing-filters.js';
 import { createOpenMapButton } from './map-assist.js';
+import { initializeAddToCollectionPrompt } from './add-to-collection.js';
 import {
   RPC_URL,
   REGISTRY_ADDRESS,
@@ -138,6 +139,7 @@ const backButton = document.querySelector('[data-back-button]');
 const backController = createBackController({ sdk, button: backButton });
 let selectionBackEntry = null;
 backController.update();
+initializeAddToCollectionPrompt({ sdk });
 
 if (els.period && !els.period.value) {
   els.period.value = 'month';


### PR DESCRIPTION
## Summary
- add a shared helper that watches in-app engagement and calls `sdk.actions.addMiniApp()` after 60 seconds
- wire the helper into the home page and each role-specific console so engaged users see the native add-to-collection prompt

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0f6e8a16c832a9f155519dfa8e0e2