### PR TITLE
Update FAQ instructions for adding mini app manually

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -307,7 +307,7 @@
           <h2>FAQ – General</h2>
           <div class="faq-group">
             <details class="faq-item"><summary>How do I add r3nt to my Farcaster Mini App collection?</summary>
-              <p>Stay active in the app for about a minute and you&rsquo;ll see the native prompt powered by <code>sdk.actions.addMiniApp()</code>. Accepting it pins r3nt to your collection so it&rsquo;s easier to find and allows notifications. You can also open the Warpcast Mini Apps drawer, search for &ldquo;r3nt&rdquo; and tap <em>Add</em>.</p>
+              <p>Stay active in the app for about a minute and you&rsquo;ll usually see the native prompt to add r3nt. Accepting it pins the mini app so it&rsquo;s easier to find and enables notifications. If the prompt doesn&rsquo;t appear, open the Warpcast Mini Apps drawer, tap <em>Manage</em>, search for &ldquo;r3nt&rdquo; and select <em>Add</em> to pin it manually.</p>
             </details>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove references to internal code from the FAQ entry about adding r3nt to a Farcaster Mini App collection
- add manual instructions for pinning r3nt when the native prompt does not appear

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e1031ac1c4832a88ae18d79ac4c543