### PR TITLE
Highlight mini app prompt links for non-mini users

### DIFF
--- a/js/miniapp-environment.js
+++ b/js/miniapp-environment.js
@@ -22,12 +22,12 @@ export async function showNonMiniAppPrompt({ sdk, container }) {
   container.innerHTML = `
     <p>
       r3nt works best inside the Farcaster Mini App.
-      <a href="${MINIAPP_URL}" target="_blank" rel="noopener noreferrer">Launch the r3nt Mini App</a>
+      <a class="miniapp-note-link" href="${MINIAPP_URL}" target="_blank" rel="noopener noreferrer">Launch the r3nt Mini App</a>
       to connect your wallet and unlock bookings.
     </p>
     <p>
       New to Farcaster?
-      <a href="${MINIAPP_REFERRAL_URL}" target="_blank" rel="noopener noreferrer">Join with this referral link</a>.
+      <a class="miniapp-note-link" href="${MINIAPP_REFERRAL_URL}" target="_blank" rel="noopener noreferrer">Join with this referral link</a>.
     </p>
   `;
   container.hidden = false;

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1622,6 +1622,26 @@ dl.summary-breakdown dd {
   line-height: 1.45;
 }
 
+.note.miniapp-note .miniapp-note-link {
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.note.miniapp-note .miniapp-note-link::after {
+  content: '↗';
+  font-size: 0.85em;
+  transition: transform var(--transition-fast);
+}
+
+.note.miniapp-note .miniapp-note-link:hover::after {
+  transform: translateX(2px);
+}
+
 .section-divider {
   border: none;
   border-top: 1px solid var(--color-border);


### PR DESCRIPTION
## Summary
- add a dedicated class to the non-mini-app prompt links for the Farcaster mini app and referral URLs
- style the prompt links with underlines, heavier weight, and an arrow indicator so they read as links at a glance

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68e23df6227c832a9120243f358a94c1