### PR TITLE
Show Farcaster cast preview images on tenant listings

### DIFF
--- a/js/ui/cards.js
+++ b/js/ui/cards.js
@@ -22,6 +22,7 @@ export function ListingCard({
   depositUSDC,
   status,
   actions = [],
+  imageUrl,
 }) {
   const visibleActions = actions.filter((a) => a?.visible !== false);
   const actionButtons = visibleActions.map((a) => el('button', { class: 'inline-button', onClick: a.onClick }, a.label));
@@ -43,7 +44,25 @@ export function ListingCard({
     headerChildren.push(el('div', { class: 'card-meta' }, metaPills));
   }
 
-  const children = [el('div', { class: 'card-header' }, headerChildren)];
+  const children = [];
+
+  const normalizedImageUrl = typeof imageUrl === 'string' ? imageUrl.trim() : '';
+  if (normalizedImageUrl) {
+    const altText = title ? `${title} preview image` : 'Listing preview image';
+    children.push(
+      el('div', { class: 'listing-card-preview-wrapper' }, [
+        el('img', {
+          class: 'listing-card-preview',
+          src: normalizedImageUrl,
+          alt: altText,
+          loading: 'lazy',
+          decoding: 'async',
+        }),
+      ]),
+    );
+  }
+
+  children.push(el('div', { class: 'card-header' }, headerChildren));
 
   if (actionButtons.length > 0) {
     children.push(el('div', { class: 'card-actions' }, actionButtons));

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -949,6 +949,21 @@ footer {
   transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
+.listing-card-preview-wrapper {
+  width: 100%;
+  aspect-ratio: 1.91 / 1;
+  overflow: hidden;
+  border-radius: calc(var(--radius-lg) - 4px);
+  background: var(--color-surface-muted, rgba(244, 246, 249, 0.7));
+}
+
+.listing-card-preview {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
 .landlord-card:focus-within,
 .listing-card:focus-within,
 .booking-entry:focus-within {


### PR DESCRIPTION
## Summary
- resolve Farcaster embed metadata with the public Warpcast client to capture embed and preview image URLs in cached listing details
- expose the preview image on tenant listing records and pass it through the render pipeline to each listing card
- render the preview image above the listing card content with styling that preserves the mini app aspect ratio and existing spacing

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5c4e8dd2c832a9a71c96c06fb9942