### PR TITLE
Switch map links to geo URI scheme

### DIFF
--- a/js/map-assist.js
+++ b/js/map-assist.js
@@ -1,7 +1,7 @@
 import { sdk } from 'https://esm.sh/@farcaster/miniapp-sdk';
 import { el } from './ui/dom.js';
 
-const GOOGLE_MAPS_SEARCH_URL = 'https://www.google.com/maps/search/?api=1';
+const GEO_URI_SCHEME = 'geo:';
 
 const defaultOptions = {
   className: 'geo-map-link',
@@ -30,8 +30,7 @@ export function createOpenMapButton(options = {}) {
     return null;
   }
 
-  const query = encodeURIComponent(coords);
-  const href = `${GOOGLE_MAPS_SEARCH_URL}&query=${query}`;
+  const href = `${GEO_URI_SCHEME}${coords}`;
 
   const mapLink = el(
     'a',


### PR DESCRIPTION
## Summary
- replace Google Maps search URL constant with a geo: URI prefix
- update map button links and mini app openUrl calls to use geo: URIs directly

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e5c932edc0832aac2f2d651c48d0d6