### PR TITLE
Adjust Farcaster link placement on tenant listing cards

### DIFF
--- a/js/tenant.js
+++ b/js/tenant.js
@@ -1642,6 +1642,7 @@ function renderListings(listings, options = {}) {
       },
     });
 
+    const farcasterUrl = buildFarcasterCastUrl(record.fid, record.castHash);
     const card = ListingCard({
       id: record.id,
       title: record.displayTitle || record.title || getListingTitle(record),
@@ -1653,6 +1654,16 @@ function renderListings(listings, options = {}) {
       status: record.active ? 'Active' : 'Inactive',
       actions: listingActions,
       imageUrl: typeof record.previewImageUrl === 'string' ? record.previewImageUrl : undefined,
+      detailLink: farcasterUrl
+        ? {
+            href: farcasterUrl,
+            label: 'View full details on Farcaster',
+            onClick: (ev) => {
+              ev.preventDefault();
+              openCast(record.fid, record.castHash, farcasterUrl);
+            },
+          }
+        : undefined,
     });
     card.dataset.address = record.address || '';
     card.dataset.displayTitle = record.displayTitle || '';
@@ -1725,20 +1736,6 @@ function renderListings(listings, options = {}) {
         }, 'Metadata'),
       );
     }
-
-    const farcasterUrl = buildFarcasterCastUrl(record.fid, record.castHash);
-    card.append(
-      el('a', {
-        href: farcasterUrl,
-        target: '_blank',
-        rel: 'noopener',
-        class: 'listing-link',
-        onClick: (ev) => {
-          ev.preventDefault();
-          openCast(record.fid, record.castHash, farcasterUrl);
-        },
-      }, 'View full details on Farcaster'),
-    );
 
     if (selectedListing && selectedListing.address && addressesEqual(selectedListing.address, record.address)) {
       card.classList.add('selected');

--- a/js/ui/cards.js
+++ b/js/ui/cards.js
@@ -23,6 +23,7 @@ export function ListingCard({
   status,
   actions = [],
   imageUrl,
+  detailLink,
 }) {
   const visibleActions = actions.filter((a) => a?.visible !== false);
   const actionButtons = visibleActions.map((a) => el('button', { class: 'inline-button', onClick: a.onClick }, a.label));
@@ -31,6 +32,23 @@ export function ListingCard({
   const headerChildren = [el('strong', {}, title || `Listing #${id}`)];
   if (summaryText) {
     headerChildren.push(el('div', { class: 'listing-summary' }, summaryText));
+  }
+
+  if (detailLink?.href) {
+    const detailLinkProps = {
+      href: detailLink.href,
+      target: '_blank',
+      rel: 'noopener',
+      class: detailLink.className || 'listing-link listing-link-subtle',
+    };
+    if (typeof detailLink.onClick === 'function') {
+      detailLinkProps.onClick = detailLink.onClick;
+    }
+    headerChildren.push(
+      el('div', { class: 'listing-farcaster-link' }, [
+        el('a', detailLinkProps, detailLink.label || 'View full details on Farcaster'),
+      ]),
+    );
   }
 
   const metaPills = [

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -727,6 +727,21 @@ footer {
   text-decoration: underline;
 }
 
+.listing-link-subtle {
+  font-weight: 500;
+  font-size: 0.95em;
+}
+
+.listing-farcaster-link {
+  margin-top: 6px;
+}
+
+.listing-farcaster-link .listing-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .onboarding-guide,
 .planner-card,
 .bookings-card,


### PR DESCRIPTION
## Summary
- move the Farcaster deep link into the tenant listing card header so it appears alongside the title and summary
- add optional detail link support to `ListingCard` and style the Farcaster link to appear lighter than the main title text

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e5d1262d88832a9987685d613c865e